### PR TITLE
Add overviews to the examples

### DIFF
--- a/example_create_test.go
+++ b/example_create_test.go
@@ -9,6 +9,7 @@ import (
 	paddle "github.com/PaddleHQ/paddle-go-sdk"
 )
 
+// Demonstrates how to create a new entity.
 func Example_create() {
 	// Create a mock HTTP server for this example - skip over this bit!
 	s := mockServerForExample(mockServerResponse{stub: &stub{paths: []stubPath{transaction}}})

--- a/example_get_test.go
+++ b/example_get_test.go
@@ -8,6 +8,7 @@ import (
 	paddle "github.com/PaddleHQ/paddle-go-sdk"
 )
 
+// Demonstrates how to get an existing entity.
 func Example_get() {
 	// Create a mock HTTP server for this example - skip over this bit!
 	s := mockServerForExample(mockServerResponse{stub: &stub{paths: []stubPath{transaction}}})

--- a/example_list_test.go
+++ b/example_list_test.go
@@ -8,6 +8,7 @@ import (
 	paddle "github.com/PaddleHQ/paddle-go-sdk"
 )
 
+// Demonstrates how to fetch a list and iterate over the provided results.
 func Example_list() {
 	// Create a mock HTTP server for this example - skip over this bit!
 	s := mockServerForExample(mockServerResponse{stub: &stub{paths: []stubPath{transactions}}})
@@ -46,7 +47,8 @@ func Example_list() {
 	//<nil>
 }
 
-func Example_list_paginate() {
+// Demonstrates how to fetch a list and iterate over the provided results, including the automatic pagination.
+func Example_pagination() {
 	// Create a mock HTTP server for this example - skip over this bit!
 	s := mockServerForExample(mockServerResponse{stub: &stub{paths: []stubPath{
 		transactionsPaginatedPg1,

--- a/example_update_test.go
+++ b/example_update_test.go
@@ -8,6 +8,7 @@ import (
 	paddle "github.com/PaddleHQ/paddle-go-sdk"
 )
 
+// Demonstrates how to update an existing entity.
 func Example_update() {
 	// Create a mock HTTP server for this example - skip over this bit!
 	s := mockServerForExample(mockServerResponse{stub: &stub{paths: []stubPath{transaction}}})

--- a/example_webhook_verifier_test.go
+++ b/example_webhook_verifier_test.go
@@ -17,6 +17,7 @@ const (
 	exampleSecretKey = `pdl_ntfset_01hsdn8d43dt7mezr1ef2jtbaw_hKkRiCGyyRhbFwIUuqiTBgI7gnWoV0Gr`
 )
 
+// Demonstrates how to verify a webhook.
 func ExampleWebhookVerifier_Verify() {
 	// Create a WebhookVerifier with your secret key
 	// You should keep your secret outside the src, e.g. as an env variable
@@ -82,6 +83,7 @@ func ExampleWebhookVerifier_Verify() {
 	// Output: {"success": true} <nil>
 }
 
+// Demonstrates how to use the WebhookVerifier as a middleware.
 func ExampleWebhookVerifier_Middleware() {
 	// Create a WebhookVerifier with your secret key
 	// You should keep your secret outside the src, e.g. as an env variable


### PR DESCRIPTION
Adds overviews to the examples to make then easier to follow:

Before:
<img width="842" alt="Screenshot 2024-05-07 at 16 35 16" src="https://github.com/PaddleHQ/paddle-go-sdk/assets/304636/a00fa646-002a-40d0-b37e-63e0e520db2c">

After:
<img width="702" alt="Screenshot 2024-05-07 at 16 34 55" src="https://github.com/PaddleHQ/paddle-go-sdk/assets/304636/51cd2cc6-b7fb-40f2-8018-1d17b52bf389">

Marked as `release:patch` so the public docs are updated.
