### PR TITLE
Use PATCH instead of POST to preview subscription changes. closes #8

### DIFF
--- a/subscriptions.go
+++ b/subscriptions.go
@@ -1066,7 +1066,7 @@ type PreviewSubscriptionRequest struct {
 
 // PreviewSubscription performs the POST operation on a Subscriptions resource.
 func (c *SubscriptionsClient) PreviewSubscription(ctx context.Context, req *PreviewSubscriptionRequest) (res *SubscriptionPreview, err error) {
-	if err := c.doer.Do(ctx, "POST", "/subscriptions/{subscription_id}/preview", req, &res); err != nil {
+	if err := c.doer.Do(ctx, "PATCH", "/subscriptions/{subscription_id}/preview", req, &res); err != nil {
 		return nil, err
 	}
 


### PR DESCRIPTION
Per [official documentation](https://developer.paddle.com/api-reference/subscriptions/preview-subscription) PATCH method should be used

> NOTE: `UpdateSubscription()` uses correct method PATCH

closes #8 