### PR TITLE
Fix non-paginated lists

### DIFF
--- a/collection.go
+++ b/collection.go
@@ -193,6 +193,10 @@ func (c *Collection[T]) UnmarshalJSON(b []byte) error {
 		}
 	}
 
+	if res.Meta.Pagination == nil {
+		return nil
+	}
+
 	nextURL, err := url.Parse(res.Meta.Pagination.Next)
 	if err != nil {
 		return err

--- a/example_list_test.go
+++ b/example_list_test.go
@@ -91,3 +91,76 @@ func Example_pagination() {
 	//txn_01hv8kxg3hxyxs9t471ms9kfsz
 	//<nil>
 }
+
+func Example_listWithoutPagination() {
+	s := mockServerForExample(mockServerResponse{stub: &stub{paths: []stubPath{
+		event_types,
+	}}})
+
+	// Create a new Paddle client.
+	client, err := paddle.New(
+		os.Getenv("PADDLE_API_KEY"),
+		paddle.WithBaseURL(s.URL), // Uses the mock server, you will not need this in your integration.
+	)
+
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+
+	ctx := context.Background()
+	// Get a collection of transactions.
+	res, err := client.ListEventTypes(ctx, &paddle.ListEventTypesRequest{})
+
+	// Iterate the transactions which will internally paginate to the next page.
+	err = res.Iter(ctx, func(v *paddle.EventType) (bool, error) {
+		fmt.Println(v.Name)
+		return true, nil
+	})
+	fmt.Println(err)
+
+	// Output:
+	//transaction.billed
+	//transaction.canceled
+	//transaction.completed
+	//transaction.created
+	//transaction.paid
+	//transaction.past_due
+	//transaction.payment_failed
+	//transaction.ready
+	//transaction.updated
+	//subscription.activated
+	//subscription.canceled
+	//subscription.created
+	//subscription.imported
+	//subscription.past_due
+	//subscription.paused
+	//subscription.resumed
+	//subscription.trialing
+	//subscription.updated
+	//product.created
+	//product.imported
+	//product.updated
+	//price.created
+	//price.imported
+	//price.updated
+	//customer.created
+	//customer.imported
+	//customer.updated
+	//address.created
+	//address.imported
+	//address.updated
+	//business.created
+	//business.imported
+	//business.updated
+	//adjustment.created
+	//adjustment.updated
+	//payout.created
+	//payout.paid
+	//discount.created
+	//discount.imported
+	//discount.updated
+	//report.created
+	//report.updated
+	//<nil>
+}

--- a/example_test.go
+++ b/example_test.go
@@ -9,6 +9,7 @@ import (
 type stubPath string
 
 const (
+	event_types              stubPath = "testdata/event_types.json"
 	events                   stubPath = "testdata/events.json"
 	transaction              stubPath = "testdata/transaction.json"
 	transactions             stubPath = "testdata/transactions.json"

--- a/testdata/event_types.json
+++ b/testdata/event_types.json
@@ -1,0 +1,343 @@
+{
+  "data": [
+    {
+      "name": "transaction.billed",
+      "description": "Occurs when a transaction is billed. Its status field changes to billed and billed_at is populated.",
+      "group": "Transaction",
+      "available_versions": [
+        1
+      ]
+    },
+    {
+      "name": "transaction.canceled",
+      "description": "Occurs when a transaction is canceled. Its status field changes to canceled.",
+      "group": "Transaction",
+      "available_versions": [
+        1
+      ]
+    },
+    {
+      "name": "transaction.completed",
+      "description": "Occurs when a transaction is completed. Its status field changes to completed.",
+      "group": "Transaction",
+      "available_versions": [
+        1
+      ]
+    },
+    {
+      "name": "transaction.created",
+      "description": "Occurs when a transaction is created.",
+      "group": "Transaction",
+      "available_versions": [
+        1
+      ]
+    },
+    {
+      "name": "transaction.paid",
+      "description": "Occurs when a transaction is paid. Its status field changes to paid.",
+      "group": "Transaction",
+      "available_versions": [
+        1
+      ]
+    },
+    {
+      "name": "transaction.past_due",
+      "description": "Occurs when a transaction becomes past due. Its status field changes to past_due.",
+      "group": "Transaction",
+      "available_versions": [
+        1
+      ]
+    },
+    {
+      "name": "transaction.payment_failed",
+      "description": "Occurs when a payment fails for a transaction. The payments array is updated with details of the payment attempt.",
+      "group": "Transaction",
+      "available_versions": [
+        1
+      ]
+    },
+    {
+      "name": "transaction.ready",
+      "description": "Occurs when a transaction is ready to be billed. Its status field changes to ready.",
+      "group": "Transaction",
+      "available_versions": [
+        1
+      ]
+    },
+    {
+      "name": "transaction.updated",
+      "description": "Occurs when a transaction is updated.",
+      "group": "Transaction",
+      "available_versions": [
+        1
+      ]
+    },
+    {
+      "name": "subscription.activated",
+      "description": "Occurs when a subscription becomes active. Its status field changes to active. This means any trial period has elapsed and Paddle has successfully billed the customer.",
+      "group": "Subscription",
+      "available_versions": [
+        1
+      ]
+    },
+    {
+      "name": "subscription.canceled",
+      "description": "Occurs when a subscription is canceled. Its status field changes to canceled.",
+      "group": "Subscription",
+      "available_versions": [
+        1
+      ]
+    },
+    {
+      "name": "subscription.created",
+      "description": "Occurs when a subscription is created. subscription.trialing or subscription.activated typically follow.",
+      "group": "Subscription",
+      "available_versions": [
+        1
+      ]
+    },
+    {
+      "name": "subscription.imported",
+      "description": "Occurs when a subscription is imported.",
+      "group": "Subscription",
+      "available_versions": [
+        1
+      ]
+    },
+    {
+      "name": "subscription.past_due",
+      "description": "Occurs when a subscription has an unpaid transaction. Its status changes to past_due.",
+      "group": "Subscription",
+      "available_versions": [
+        1
+      ]
+    },
+    {
+      "name": "subscription.paused",
+      "description": "Occurs when a subscription is paused. Its status field changes to paused.",
+      "group": "Subscription",
+      "available_versions": [
+        1
+      ]
+    },
+    {
+      "name": "subscription.resumed",
+      "description": "Occurs when a subscription is resumed after being paused. Its status field changes to active.",
+      "group": "Subscription",
+      "available_versions": [
+        1
+      ]
+    },
+    {
+      "name": "subscription.trialing",
+      "description": "Occurs when a subscription enters trial period.",
+      "group": "Subscription",
+      "available_versions": [
+        1
+      ]
+    },
+    {
+      "name": "subscription.updated",
+      "description": "Occurs when a subscription is updated.",
+      "group": "Subscription",
+      "available_versions": [
+        1
+      ]
+    },
+    {
+      "name": "product.created",
+      "description": "Occurs when a product is created.",
+      "group": "Product",
+      "available_versions": [
+        1
+      ]
+    },
+    {
+      "name": "product.imported",
+      "description": "Occurs when a product is imported.",
+      "group": "Product",
+      "available_versions": [
+        1
+      ]
+    },
+    {
+      "name": "product.updated",
+      "description": "Occurs when a product is updated.",
+      "group": "Product",
+      "available_versions": [
+        1
+      ]
+    },
+    {
+      "name": "price.created",
+      "description": "Occurs when a price is created.",
+      "group": "Price",
+      "available_versions": [
+        1
+      ]
+    },
+    {
+      "name": "price.imported",
+      "description": "Occurs when a price is imported.",
+      "group": "Price",
+      "available_versions": [
+        1
+      ]
+    },
+    {
+      "name": "price.updated",
+      "description": "Occurs when a price is updated.",
+      "group": "Price",
+      "available_versions": [
+        1
+      ]
+    },
+    {
+      "name": "customer.created",
+      "description": "Occurs when a customer is created.",
+      "group": "Customer",
+      "available_versions": [
+        1
+      ]
+    },
+    {
+      "name": "customer.imported",
+      "description": "Occurs when a customer is imported.",
+      "group": "Customer",
+      "available_versions": [
+        1
+      ]
+    },
+    {
+      "name": "customer.updated",
+      "description": "Occurs when a customer is updated.",
+      "group": "Customer",
+      "available_versions": [
+        1
+      ]
+    },
+    {
+      "name": "address.created",
+      "description": "Occurs when an address is created.",
+      "group": "Address",
+      "available_versions": [
+        1
+      ]
+    },
+    {
+      "name": "address.imported",
+      "description": "Occurs when a address is imported.",
+      "group": "Address",
+      "available_versions": [
+        1
+      ]
+    },
+    {
+      "name": "address.updated",
+      "description": "Occurs when an address is updated.",
+      "group": "Address",
+      "available_versions": [
+        1
+      ]
+    },
+    {
+      "name": "business.created",
+      "description": "Occurs when a business is created.",
+      "group": "Business",
+      "available_versions": [
+        1
+      ]
+    },
+    {
+      "name": "business.imported",
+      "description": "Occurs when a business is imported.",
+      "group": "Business",
+      "available_versions": [
+        1
+      ]
+    },
+    {
+      "name": "business.updated",
+      "description": "Occurs when a business is updated.",
+      "group": "Business",
+      "available_versions": [
+        1
+      ]
+    },
+    {
+      "name": "adjustment.created",
+      "description": "Occurs when an adjustment is created.",
+      "group": "Adjustment",
+      "available_versions": [
+        1
+      ]
+    },
+    {
+      "name": "adjustment.updated",
+      "description": "Occurs when an adjustment is updated, the only time an adjustment will be updated is when the status changes from pending to approved or from pending to rejected.",
+      "group": "Adjustment",
+      "available_versions": [
+        1
+      ]
+    },
+    {
+      "name": "payout.created",
+      "description": "Occurs when a payout is created.",
+      "group": "Payout",
+      "available_versions": [
+        1
+      ]
+    },
+    {
+      "name": "payout.paid",
+      "description": "Occurs when a payout is paid.",
+      "group": "Payout",
+      "available_versions": [
+        1
+      ]
+    },
+    {
+      "name": "discount.created",
+      "description": "Occurs when a discount is created.",
+      "group": "Discount",
+      "available_versions": [
+        1
+      ]
+    },
+    {
+      "name": "discount.imported",
+      "description": "Occurs when a discount is imported.",
+      "group": "Discount",
+      "available_versions": [
+        1
+      ]
+    },
+    {
+      "name": "discount.updated",
+      "description": "Occurs when a discount is updated.",
+      "group": "Discount",
+      "available_versions": [
+        1
+      ]
+    },
+    {
+      "name": "report.created",
+      "description": "Occurs when a report is created.",
+      "group": "Report",
+      "available_versions": [
+        1
+      ]
+    },
+    {
+      "name": "report.updated",
+      "description": "Occurs when a report is updated.",
+      "group": "Report",
+      "available_versions": [
+        1
+      ]
+    }
+  ],
+  "meta": {
+    "request_id": "24a742a8-4701-40d0-a296-f90aaaaccebe"
+  }
+}


### PR DESCRIPTION
Not all lists (i.e. `eventTypes`) have pagination.

When using the SDK for these endpoints then the SDK fails with a nil pointer exception.

This is due to the SDK attempting to parse the non existent pagination.

We should do a nil check before reading the pagination.