### PR TITLE
!feat: Improved type definitions

### DIFF
--- a/adjustments.go
+++ b/adjustments.go
@@ -120,6 +120,18 @@ var ErrAdjustmentCannotAdjustImportedTransaction = &paddleerr.Error{
 	Type: paddleerr.ErrorTypeRequestError,
 }
 
+// AdjustmentActionQuery: Return entities for the specified action..
+type AdjustmentActionQuery string
+
+const (
+	AdjustmentActionQueryChargeback        AdjustmentActionQuery = "chargeback"
+	AdjustmentActionQueryChargebackReverse AdjustmentActionQuery = "chargeback_reverse"
+	AdjustmentActionQueryChargebackWarning AdjustmentActionQuery = "chargeback_warning"
+	AdjustmentActionQueryCredit            AdjustmentActionQuery = "credit"
+	AdjustmentActionQueryCreditReverse     AdjustmentActionQuery = "credit_reverse"
+	AdjustmentActionQueryRefund            AdjustmentActionQuery = "refund"
+)
+
 // CustomerBalance: Totals for this credit balance. Where a customer has more than one subscription in this currency with a credit balance, includes totals for all subscriptions.
 type CustomerBalance struct {
 	// Available: Total amount of credit available to use.
@@ -196,7 +208,7 @@ func (c *AdjustmentsClient) ListAdjustments(ctx context.Context, req *ListAdjust
 // CreateAdjustmentRequest is given as an input to CreateAdjustment.
 type CreateAdjustmentRequest struct {
 	// Action: How this adjustment impacts the related transaction.
-	Action Action `json:"action,omitempty"`
+	Action AdjustmentAction `json:"action,omitempty"`
 	// Items: List of transaction items to adjust.
 	Items []AdjustmentItem `json:"items,omitempty"`
 	// Reason: Why this adjustment was created. Appears in the Paddle dashboard. Retained for record-keeping purposes.

--- a/ip_addresses.go
+++ b/ip_addresses.go
@@ -4,7 +4,7 @@ package paddle
 
 import "context"
 
-type IPAddressesData struct {
+type IPAddress struct {
 	// IPv4CIDRs: List of Paddle IPv4 CIDRs.
 	IPv4CIDRs []string `json:"ipv4_cidrs,omitempty"`
 }
@@ -18,7 +18,7 @@ type IPAddressesClient struct {
 type GetIPAddressesRequest struct{}
 
 // GetIPAddresses performs the GET operation on a IP addresses resource.
-func (c *IPAddressesClient) GetIPAddresses(ctx context.Context, req *GetIPAddressesRequest) (res *IPAddressesData, err error) {
+func (c *IPAddressesClient) GetIPAddresses(ctx context.Context, req *GetIPAddressesRequest) (res *IPAddress, err error) {
 	if err := c.doer.Do(ctx, "GET", "/ips", req, &res); err != nil {
 		return nil, err
 	}

--- a/notifications.go
+++ b/notifications.go
@@ -55,12 +55,12 @@ const (
 	NotificationStatusFailed       NotificationStatus = "failed"
 )
 
-// Origin: Describes how this notification was created..
-type Origin string
+// NotificationOrigin: Describes how this notification was created..
+type NotificationOrigin string
 
 const (
-	OriginEvent  Origin = "event"
-	OriginReplay Origin = "replay"
+	NotificationOriginEvent  NotificationOrigin = "event"
+	NotificationOriginReplay NotificationOrigin = "replay"
 )
 
 // Notification: Represents a notification entity.
@@ -80,7 +80,7 @@ type Notification struct {
 	// ReplayedAt: RFC 3339 datetime string of when this notification was replayed. `null` if not replayed.
 	ReplayedAt *string `json:"replayed_at,omitempty"`
 	// Origin: Describes how this notification was created.
-	Origin Origin `json:"origin,omitempty"`
+	Origin NotificationOrigin `json:"origin,omitempty"`
 	// LastAttemptAt: RFC 3339 datetime string of when this notification was last attempted.
 	LastAttemptAt *string `json:"last_attempt_at,omitempty"`
 	// RetryAt: RFC 3339 datetime string of when this notification is scheduled to be retried.

--- a/pkg/paddlenotification/adjustments.go
+++ b/pkg/paddlenotification/adjustments.go
@@ -16,16 +16,16 @@ type AdjustmentUpdated struct {
 	Data AdjustmentNotification `json:"data"`
 }
 
-// Action: How this adjustment impacts the related transaction..
-type Action string
+// AdjustmentAction: How this adjustment impacts the related transaction..
+type AdjustmentAction string
 
 const (
-	ActionCredit            Action = "credit"
-	ActionRefund            Action = "refund"
-	ActionChargeback        Action = "chargeback"
-	ActionChargebackReverse Action = "chargeback_reverse"
-	ActionChargebackWarning Action = "chargeback_warning"
-	ActionCreditReverse     Action = "credit_reverse"
+	AdjustmentActionCredit            AdjustmentAction = "credit"
+	AdjustmentActionRefund            AdjustmentAction = "refund"
+	AdjustmentActionChargeback        AdjustmentAction = "chargeback"
+	AdjustmentActionChargebackReverse AdjustmentAction = "chargeback_reverse"
+	AdjustmentActionChargebackWarning AdjustmentAction = "chargeback_warning"
+	AdjustmentActionCreditReverse     AdjustmentAction = "credit_reverse"
 )
 
 /*
@@ -130,7 +130,7 @@ type AdjustmentNotification struct {
 	// ID: Unique Paddle ID for this adjustment entity, prefixed with `adj_`.
 	ID string `json:"id,omitempty"`
 	// Action: How this adjustment impacts the related transaction.
-	Action Action `json:"action,omitempty"`
+	Action AdjustmentAction `json:"action,omitempty"`
 	// TransactionID: Paddle ID of the transaction that this adjustment is for, prefixed with `txn_`.
 	TransactionID string `json:"transaction_id,omitempty"`
 	/*

--- a/shared.go
+++ b/shared.go
@@ -1105,7 +1105,7 @@ type Adjustment struct {
 	// ID: Unique Paddle ID for this adjustment entity, prefixed with `adj_`.
 	ID string `json:"id,omitempty"`
 	// Action: How this adjustment impacts the related transaction.
-	Action Action `json:"action,omitempty"`
+	Action AdjustmentAction `json:"action,omitempty"`
 	// TransactionID: Paddle ID of the transaction that this adjustment is for, prefixed with `txn_`.
 	TransactionID string `json:"transaction_id,omitempty"`
 	/*

--- a/shared.go
+++ b/shared.go
@@ -991,16 +991,16 @@ type Address struct {
 	ImportMeta *ImportMeta `json:"import_meta,omitempty"`
 }
 
-// Action: How this adjustment impacts the related transaction..
-type Action string
+// AdjustmentAction: How this adjustment impacts the related transaction..
+type AdjustmentAction string
 
 const (
-	ActionCredit            Action = "credit"
-	ActionRefund            Action = "refund"
-	ActionChargeback        Action = "chargeback"
-	ActionChargebackReverse Action = "chargeback_reverse"
-	ActionChargebackWarning Action = "chargeback_warning"
-	ActionCreditReverse     Action = "credit_reverse"
+	AdjustmentActionCredit            AdjustmentAction = "credit"
+	AdjustmentActionRefund            AdjustmentAction = "refund"
+	AdjustmentActionChargeback        AdjustmentAction = "chargeback"
+	AdjustmentActionChargebackReverse AdjustmentAction = "chargeback_reverse"
+	AdjustmentActionChargebackWarning AdjustmentAction = "chargeback_warning"
+	AdjustmentActionCreditReverse     AdjustmentAction = "credit_reverse"
 )
 
 /*

--- a/subscriptions.go
+++ b/subscriptions.go
@@ -636,22 +636,6 @@ type ResumeImmediately struct {
 	EffectiveFrom *EffectiveFrom `json:"effective_from,omitempty"`
 }
 
-// Credit: Details of any credit adjustments. Paddle creates adjustments against existing transactions when prorating.
-type Credit struct {
-	// Amount: Total of any credit adjustments created for this update.
-	Amount string `json:"amount,omitempty"`
-	// CurrencyCode: Three-letter ISO 4217 currency code for adjustments.
-	CurrencyCode CurrencyCode `json:"currency_code,omitempty"`
-}
-
-// Charge: Details of the transaction to be created for this update. Paddle creates a transaction to bill for new charges.
-type Charge struct {
-	// Amount: Total of the transaction to be created for this update.
-	Amount string `json:"amount,omitempty"`
-	// CurrencyCode: Three-letter ISO 4217 currency code for the transaction to be created.
-	CurrencyCode CurrencyCode `json:"currency_code,omitempty"`
-}
-
 // UpdateSummaryResultAction: Whether the subscription change results in a prorated credit or a charge..
 type UpdateSummaryResultAction string
 
@@ -660,8 +644,8 @@ const (
 	UpdateSummaryResultActionCharge UpdateSummaryResultAction = "charge"
 )
 
-// Result: Details of the result of credits and charges. Where the total of any credit adjustments is greater than the total charge, the result is a prorated credit; otherwise, the result is a prorated charge.
-type Result struct {
+// UpdateSummaryResult: Details of the result of credits and charges. Where the total of any credit adjustments is greater than the total charge, the result is a prorated credit; otherwise, the result is a prorated charge.
+type UpdateSummaryResult struct {
 	// Action: Whether the subscription change results in a prorated credit or a charge.
 	Action UpdateSummaryResultAction `json:"action,omitempty"`
 	// Amount: Amount representing the result of this update, either a charge or a credit.

--- a/subscriptions.go
+++ b/subscriptions.go
@@ -654,10 +654,10 @@ type UpdateSummaryResult struct {
 	CurrencyCode CurrencyCode `json:"currency_code,omitempty"`
 }
 
-	// Credit: Details of any credit adjustments. Paddle creates adjustments against existing transactions when prorating.
-	Credit Credit `json:"credit,omitempty"`
 // SubscriptionPreviewUpdateSummary: Impact of this subscription change. Includes whether the change results in a charge or credit, and totals for prorated amounts.
 type SubscriptionPreviewUpdateSummary struct {
+	// Credit: Details of any credit adjustments created for this update. Paddle creates adjustments against existing transactions when prorating.
+	Credit Money `json:"credit,omitempty"`
 	// Charge: Details of the transaction to be created for this update. Paddle creates a transaction to bill for new charges.
 	Charge Charge `json:"charge,omitempty"`
 	// Result: Details of the result of credits and charges. Where the total of any credit adjustments is greater than the total charge, the result is a prorated credit; otherwise, the result is a prorated charge.
@@ -720,8 +720,8 @@ type SubscriptionPreview struct {
 	ImportMeta *ImportMeta `json:"import_meta,omitempty"`
 }
 
-// SubscriptionsSubscriptionsCatalogItem: Add a catalog item to a subscription. In this case, the product and price that you're billing for exist in your product catalog in Paddle.
-type SubscriptionsSubscriptionsCatalogItem struct {
+// SubscriptionsCatalogItem: Add a catalog item to a subscription. In this case, the product and price that you're billing for exist in your product catalog in Paddle.
+type SubscriptionsCatalogItem struct {
 	// Quantity: Quantity to bill for.
 	Quantity int `json:"quantity,omitempty"`
 	// PriceID: Paddle ID of an an existing catalog price to bill for.
@@ -1084,10 +1084,10 @@ func (c *SubscriptionsClient) PreviewSubscription(ctx context.Context, req *Prev
 	return res, nil
 }
 
-// NewCreateSubscriptionChargeItemsSubscriptionsSubscriptionsCatalogItem takes a SubscriptionsSubscriptionsCatalogItem type
+// NewCreateSubscriptionChargeItemsSubscriptionsCatalogItem takes a SubscriptionsCatalogItem type
 // and creates a CreateSubscriptionChargeItems for use in a request.
-func NewCreateSubscriptionChargeItemsSubscriptionsSubscriptionsCatalogItem(r *SubscriptionsSubscriptionsCatalogItem) *CreateSubscriptionChargeItems {
-	return &CreateSubscriptionChargeItems{SubscriptionsSubscriptionsCatalogItem: r}
+func NewCreateSubscriptionChargeItemsSubscriptionsCatalogItem(r *SubscriptionsCatalogItem) *CreateSubscriptionChargeItems {
+	return &CreateSubscriptionChargeItems{SubscriptionsCatalogItem: r}
 }
 
 // NewCreateSubscriptionChargeItemsSubscriptionsNonCatalogPriceForAnExistingProduct takes a SubscriptionsNonCatalogPriceForAnExistingProduct type
@@ -1103,27 +1103,27 @@ func NewCreateSubscriptionChargeItemsSubscriptionsNonCatalogPriceAndProduct(r *S
 }
 
 // CreateSubscriptionChargeItems represents a union request type of the following types:
-//   - `SubscriptionsSubscriptionsCatalogItem`
+//   - `SubscriptionsCatalogItem`
 //   - `SubscriptionsNonCatalogPriceForAnExistingProduct`
 //   - `SubscriptionsNonCatalogPriceAndProduct`
 //
 // The following constructor functions can be used to create a new instance of this type.
-//   - `NewCreateSubscriptionChargeItemsSubscriptionsSubscriptionsCatalogItem()`
+//   - `NewCreateSubscriptionChargeItemsSubscriptionsCatalogItem()`
 //   - `NewCreateSubscriptionChargeItemsSubscriptionsNonCatalogPriceForAnExistingProduct()`
 //   - `NewCreateSubscriptionChargeItemsSubscriptionsNonCatalogPriceAndProduct()`
 //
 // Only one of the values can be set at a time, the first non-nil value will be used in the request.
 // Items: Add a non-catalog price for a non-catalog product in your catalog to a subscription. In this case, the product and price that you're billing for are specific to this transaction.
 type CreateSubscriptionChargeItems struct {
-	*SubscriptionsSubscriptionsCatalogItem
+	*SubscriptionsCatalogItem
 	*SubscriptionsNonCatalogPriceForAnExistingProduct
 	*SubscriptionsNonCatalogPriceAndProduct
 }
 
 // MarshalJSON implements the json.Marshaler interface.
 func (u CreateSubscriptionChargeItems) MarshalJSON() ([]byte, error) {
-	if u.SubscriptionsSubscriptionsCatalogItem != nil {
-		return json.Marshal(u.SubscriptionsSubscriptionsCatalogItem)
+	if u.SubscriptionsCatalogItem != nil {
+		return json.Marshal(u.SubscriptionsCatalogItem)
 	}
 
 	if u.SubscriptionsNonCatalogPriceForAnExistingProduct != nil {
@@ -1159,10 +1159,10 @@ func (c *SubscriptionsClient) CreateSubscriptionCharge(ctx context.Context, req 
 	return res, nil
 }
 
-// NewPreviewSubscriptionChargeItemsSubscriptionsSubscriptionsCatalogItem takes a SubscriptionsSubscriptionsCatalogItem type
+// NewPreviewSubscriptionChargeItemsSubscriptionsCatalogItem takes a SubscriptionsCatalogItem type
 // and creates a PreviewSubscriptionChargeItems for use in a request.
-func NewPreviewSubscriptionChargeItemsSubscriptionsSubscriptionsCatalogItem(r *SubscriptionsSubscriptionsCatalogItem) *PreviewSubscriptionChargeItems {
-	return &PreviewSubscriptionChargeItems{SubscriptionsSubscriptionsCatalogItem: r}
+func NewPreviewSubscriptionChargeItemsSubscriptionsCatalogItem(r *SubscriptionsCatalogItem) *PreviewSubscriptionChargeItems {
+	return &PreviewSubscriptionChargeItems{SubscriptionsCatalogItem: r}
 }
 
 // NewPreviewSubscriptionChargeItemsSubscriptionsNonCatalogPriceForAnExistingProduct takes a SubscriptionsNonCatalogPriceForAnExistingProduct type
@@ -1178,27 +1178,27 @@ func NewPreviewSubscriptionChargeItemsSubscriptionsNonCatalogPriceAndProduct(r *
 }
 
 // PreviewSubscriptionChargeItems represents a union request type of the following types:
-//   - `SubscriptionsSubscriptionsCatalogItem`
+//   - `SubscriptionsCatalogItem`
 //   - `SubscriptionsNonCatalogPriceForAnExistingProduct`
 //   - `SubscriptionsNonCatalogPriceAndProduct`
 //
 // The following constructor functions can be used to create a new instance of this type.
-//   - `NewPreviewSubscriptionChargeItemsSubscriptionsSubscriptionsCatalogItem()`
+//   - `NewPreviewSubscriptionChargeItemsSubscriptionsCatalogItem()`
 //   - `NewPreviewSubscriptionChargeItemsSubscriptionsNonCatalogPriceForAnExistingProduct()`
 //   - `NewPreviewSubscriptionChargeItemsSubscriptionsNonCatalogPriceAndProduct()`
 //
 // Only one of the values can be set at a time, the first non-nil value will be used in the request.
 // Items: Add a non-catalog price for a non-catalog product in your catalog to a subscription. In this case, the product and price that you're billing for are specific to this transaction.
 type PreviewSubscriptionChargeItems struct {
-	*SubscriptionsSubscriptionsCatalogItem
+	*SubscriptionsCatalogItem
 	*SubscriptionsNonCatalogPriceForAnExistingProduct
 	*SubscriptionsNonCatalogPriceAndProduct
 }
 
 // MarshalJSON implements the json.Marshaler interface.
 func (u PreviewSubscriptionChargeItems) MarshalJSON() ([]byte, error) {
-	if u.SubscriptionsSubscriptionsCatalogItem != nil {
-		return json.Marshal(u.SubscriptionsSubscriptionsCatalogItem)
+	if u.SubscriptionsCatalogItem != nil {
+		return json.Marshal(u.SubscriptionsCatalogItem)
 	}
 
 	if u.SubscriptionsNonCatalogPriceForAnExistingProduct != nil {

--- a/subscriptions.go
+++ b/subscriptions.go
@@ -654,10 +654,10 @@ type UpdateSummaryResult struct {
 	CurrencyCode CurrencyCode `json:"currency_code,omitempty"`
 }
 
-// PreviewSubscriptionUpdateSummary: Impact of this subscription change. Includes whether the change results in a charge or credit, and totals for prorated amounts.
-type PreviewSubscriptionUpdateSummary struct {
 	// Credit: Details of any credit adjustments. Paddle creates adjustments against existing transactions when prorating.
 	Credit Credit `json:"credit,omitempty"`
+// SubscriptionPreviewUpdateSummary: Impact of this subscription change. Includes whether the change results in a charge or credit, and totals for prorated amounts.
+type SubscriptionPreviewUpdateSummary struct {
 	// Charge: Details of the transaction to be created for this update. Paddle creates a transaction to bill for new charges.
 	Charge Charge `json:"charge,omitempty"`
 	// Result: Details of the result of credits and charges. Where the total of any credit adjustments is greater than the total charge, the result is a prorated credit; otherwise, the result is a prorated charge.
@@ -715,7 +715,7 @@ type SubscriptionPreview struct {
 	// RecurringTransactionDetails: Preview of the recurring transaction for this subscription. This is what the customer can expect to be billed when there are no prorated or one-time charges.
 	RecurringTransactionDetails SubscriptionTransactionDetailsPreview `json:"recurring_transaction_details,omitempty"`
 	// UpdateSummary: Impact of this subscription change. Includes whether the change results in a charge or credit, and totals for prorated amounts.
-	UpdateSummary *PreviewSubscriptionUpdateSummary `json:"update_summary,omitempty"`
+	UpdateSummary *SubscriptionPreviewUpdateSummary `json:"update_summary,omitempty"`
 	// ImportMeta: Import information for this entity. `null` if this entity is not imported.
 	ImportMeta *ImportMeta `json:"import_meta,omitempty"`
 }

--- a/subscriptions.go
+++ b/subscriptions.go
@@ -652,18 +652,18 @@ type Charge struct {
 	CurrencyCode CurrencyCode `json:"currency_code,omitempty"`
 }
 
-// ResultAction: Whether the subscription change results in a prorated credit or a charge..
-type ResultAction string
+// UpdateSummaryResultAction: Whether the subscription change results in a prorated credit or a charge..
+type UpdateSummaryResultAction string
 
 const (
-	ResultActionCredit ResultAction = "credit"
-	ResultActionCharge ResultAction = "charge"
+	UpdateSummaryResultActionCredit UpdateSummaryResultAction = "credit"
+	UpdateSummaryResultActionCharge UpdateSummaryResultAction = "charge"
 )
 
 // Result: Details of the result of credits and charges. Where the total of any credit adjustments is greater than the total charge, the result is a prorated credit; otherwise, the result is a prorated charge.
 type Result struct {
 	// Action: Whether the subscription change results in a prorated credit or a charge.
-	Action ResultAction `json:"action,omitempty"`
+	Action UpdateSummaryResultAction `json:"action,omitempty"`
 	// Amount: Amount representing the result of this update, either a charge or a credit.
 	Amount string `json:"amount,omitempty"`
 	// CurrencyCode: Three-letter ISO 4217 currency code for the transaction or adjustment.

--- a/subscriptions.go
+++ b/subscriptions.go
@@ -659,9 +659,9 @@ type SubscriptionPreviewUpdateSummary struct {
 	// Credit: Details of any credit adjustments created for this update. Paddle creates adjustments against existing transactions when prorating.
 	Credit Money `json:"credit,omitempty"`
 	// Charge: Details of the transaction to be created for this update. Paddle creates a transaction to bill for new charges.
-	Charge Charge `json:"charge,omitempty"`
+	Charge Money `json:"charge,omitempty"`
 	// Result: Details of the result of credits and charges. Where the total of any credit adjustments is greater than the total charge, the result is a prorated credit; otherwise, the result is a prorated charge.
-	Result Result `json:"result,omitempty"`
+	Result UpdateSummaryResult `json:"result,omitempty"`
 }
 
 // SubscriptionPreview: Represents a subscription preview when previewing a subscription.

--- a/subscriptions.go
+++ b/subscriptions.go
@@ -583,8 +583,8 @@ type SubscriptionsDiscount struct {
 	EffectiveFrom EffectiveFrom `json:"effective_from,omitempty"`
 }
 
-// SubscriptionsCatalogItem: Add or update a catalog item to a subscription. In this case, the product and price that you're billing for exist in your product catalog in Paddle.
-type SubscriptionsCatalogItem struct {
+// SubscriptionsUpdateCatalogItem: Add or update a catalog item to a subscription. In this case, the product and price that you're billing for exist in your product catalog in Paddle.
+type SubscriptionsUpdateCatalogItem struct {
 	// PriceID: Paddle ID for the price to add to this subscription, prefixed with `pri_`.
 	PriceID string `json:"price_id,omitempty"`
 	// Quantity: Quantity of this item to add to the subscription. If updating an existing item and not changing the quantity, you may omit `quantity`.
@@ -852,7 +852,7 @@ type UpdateSubscriptionRequest struct {
 	// ScheduledChange: Change that's scheduled to be applied to a subscription. When updating, you may only set to `null` to remove a scheduled change. Use the pause subscription, cancel subscription, and resume subscription operations to create scheduled changes.
 	ScheduledChange *PatchField[*SubscriptionScheduledChange] `json:"scheduled_change,omitempty"`
 	// Items: Add or update a catalog item to a subscription. In this case, the product and price that you're billing for exist in your product catalog in Paddle.
-	Items *PatchField[[]SubscriptionsCatalogItem] `json:"items,omitempty"`
+	Items *PatchField[[]SubscriptionsUpdateCatalogItem] `json:"items,omitempty"`
 	// CustomData: Your own structured key-value data.
 	CustomData *PatchField[CustomData] `json:"custom_data,omitempty"`
 	/*
@@ -1076,7 +1076,7 @@ type PreviewSubscriptionRequest struct {
 	// ScheduledChange: Change that's scheduled to be applied to a subscription. When updating, you may only set to `null` to remove a scheduled change. Use the pause subscription, cancel subscription, and resume subscription operations to create scheduled changes.
 	ScheduledChange *PatchField[*SubscriptionScheduledChange] `json:"scheduled_change,omitempty"`
 	// Items: Add or update a catalog item to a subscription. In this case, the product and price that you're billing for exist in your product catalog in Paddle.
-	Items *PatchField[[]SubscriptionsCatalogItem] `json:"items,omitempty"`
+	Items *PatchField[[]SubscriptionsUpdateCatalogItem] `json:"items,omitempty"`
 	// CustomData: Your own structured key-value data.
 	CustomData *PatchField[CustomData] `json:"custom_data,omitempty"`
 	/*

--- a/subscriptions.go
+++ b/subscriptions.go
@@ -1036,8 +1036,8 @@ func (c *SubscriptionsClient) GetSubscriptionUpdatePaymentMethodTransaction(ctx 
 	return res, nil
 }
 
-// PreviewSubscriptionRequest is given as an input to PreviewSubscription.
-type PreviewSubscriptionRequest struct {
+// PreviewSubscriptionUpdateRequest is given as an input to PreviewSubscriptionUpdate.
+type PreviewSubscriptionUpdateRequest struct {
 	// URL path parameters.
 	SubscriptionID string `in:"path=subscription_id" json:"-"`
 
@@ -1075,8 +1075,8 @@ type PreviewSubscriptionRequest struct {
 	OnPaymentFailure *PatchField[SubscriptionOnPaymentFailure] `json:"on_payment_failure,omitempty"`
 }
 
-// PreviewSubscription performs the PATCH operation on a Subscriptions resource.
-func (c *SubscriptionsClient) PreviewSubscription(ctx context.Context, req *PreviewSubscriptionRequest) (res *SubscriptionPreview, err error) {
+// PreviewSubscriptionUpdate performs the PATCH operation on a Subscriptions resource.
+func (c *SubscriptionsClient) PreviewSubscriptionUpdate(ctx context.Context, req *PreviewSubscriptionUpdateRequest) (res *SubscriptionPreview, err error) {
 	if err := c.doer.Do(ctx, "PATCH", "/subscriptions/{subscription_id}/preview", req, &res); err != nil {
 		return nil, err
 	}

--- a/transactions.go
+++ b/transactions.go
@@ -240,8 +240,8 @@ var ErrTransactionPaymentMethodChangeFieldImmutable = &paddleerr.Error{
 	Type: paddleerr.ErrorTypeRequestError,
 }
 
-// Breakdown: Breakdown of the total adjustments by adjustment action.
-type Breakdown struct {
+// AdjustmentsTotalsBreakdown: Breakdown of the total adjustments by adjustment action.
+type AdjustmentsTotalsBreakdown struct {
 	// Credit: Total amount of credit adjustments.
 	Credit string `json:"credit,omitempty"`
 	// Refund: Total amount of refund adjustments.
@@ -269,7 +269,7 @@ type AdjustmentsTotals struct {
 	*/
 	Earnings string `json:"earnings,omitempty"`
 	// Breakdown: Breakdown of the total adjustments by adjustment action.
-	Breakdown Breakdown `json:"breakdown,omitempty"`
+	Breakdown AdjustmentsTotalsBreakdown `json:"breakdown,omitempty"`
 	// CurrencyCode: Three-letter ISO 4217 currency code used for adjustments for this transaction.
 	CurrencyCode CurrencyCode `json:"currency_code,omitempty"`
 }

--- a/transactions.go
+++ b/transactions.go
@@ -460,44 +460,44 @@ type TransactionsNonCatalogPriceAndProduct struct {
 	Price TransactionPriceCreateWithProduct `json:"price,omitempty"`
 }
 
-// NewCountryAndZipPostalCodeItemsTransactionsCatalogItem takes a TransactionsCatalogItem type
-// and creates a CountryAndZipPostalCodeItems for use in a request.
-func NewCountryAndZipPostalCodeItemsTransactionsCatalogItem(r *TransactionsCatalogItem) *CountryAndZipPostalCodeItems {
-	return &CountryAndZipPostalCodeItems{TransactionsCatalogItem: r}
+// NewTransactionPreviewByAddressItemsTransactionsCatalogItem takes a TransactionsCatalogItem type
+// and creates a TransactionPreviewByAddressItems for use in a request.
+func NewTransactionPreviewByAddressItemsTransactionsCatalogItem(r *TransactionsCatalogItem) *TransactionPreviewByAddressItems {
+	return &TransactionPreviewByAddressItems{TransactionsCatalogItem: r}
 }
 
-// NewCountryAndZipPostalCodeItemsTransactionsNonCatalogPriceForAnExistingProduct takes a TransactionsNonCatalogPriceForAnExistingProduct type
-// and creates a CountryAndZipPostalCodeItems for use in a request.
-func NewCountryAndZipPostalCodeItemsTransactionsNonCatalogPriceForAnExistingProduct(r *TransactionsNonCatalogPriceForAnExistingProduct) *CountryAndZipPostalCodeItems {
-	return &CountryAndZipPostalCodeItems{TransactionsNonCatalogPriceForAnExistingProduct: r}
+// NewTransactionPreviewByAddressItemsTransactionsNonCatalogPriceForAnExistingProduct takes a TransactionsNonCatalogPriceForAnExistingProduct type
+// and creates a TransactionPreviewByAddressItems for use in a request.
+func NewTransactionPreviewByAddressItemsTransactionsNonCatalogPriceForAnExistingProduct(r *TransactionsNonCatalogPriceForAnExistingProduct) *TransactionPreviewByAddressItems {
+	return &TransactionPreviewByAddressItems{TransactionsNonCatalogPriceForAnExistingProduct: r}
 }
 
-// NewCountryAndZipPostalCodeItemsTransactionsNonCatalogPriceAndProduct takes a TransactionsNonCatalogPriceAndProduct type
-// and creates a CountryAndZipPostalCodeItems for use in a request.
-func NewCountryAndZipPostalCodeItemsTransactionsNonCatalogPriceAndProduct(r *TransactionsNonCatalogPriceAndProduct) *CountryAndZipPostalCodeItems {
-	return &CountryAndZipPostalCodeItems{TransactionsNonCatalogPriceAndProduct: r}
+// NewTransactionPreviewByAddressItemsTransactionsNonCatalogPriceAndProduct takes a TransactionsNonCatalogPriceAndProduct type
+// and creates a TransactionPreviewByAddressItems for use in a request.
+func NewTransactionPreviewByAddressItemsTransactionsNonCatalogPriceAndProduct(r *TransactionsNonCatalogPriceAndProduct) *TransactionPreviewByAddressItems {
+	return &TransactionPreviewByAddressItems{TransactionsNonCatalogPriceAndProduct: r}
 }
 
-// CountryAndZipPostalCodeItems represents a union request type of the following types:
+// TransactionPreviewByAddressItems represents a union request type of the following types:
 //   - `TransactionsCatalogItem`
 //   - `TransactionsNonCatalogPriceForAnExistingProduct`
 //   - `TransactionsNonCatalogPriceAndProduct`
 //
 // The following constructor functions can be used to create a new instance of this type.
-//   - `NewCountryAndZipPostalCodeItemsTransactionsCatalogItem()`
-//   - `NewCountryAndZipPostalCodeItemsTransactionsNonCatalogPriceForAnExistingProduct()`
-//   - `NewCountryAndZipPostalCodeItemsTransactionsNonCatalogPriceAndProduct()`
+//   - `NewTransactionPreviewByAddressItemsTransactionsCatalogItem()`
+//   - `NewTransactionPreviewByAddressItemsTransactionsNonCatalogPriceForAnExistingProduct()`
+//   - `NewTransactionPreviewByAddressItemsTransactionsNonCatalogPriceAndProduct()`
 //
 // Only one of the values can be set at a time, the first non-nil value will be used in the request.
 // Items: Add a non-catalog price for a non-catalog product in your catalog to a transaction. In this case, the product and price that you're billing for are specific to this transaction.
-type CountryAndZipPostalCodeItems struct {
+type TransactionPreviewByAddressItems struct {
 	*TransactionsCatalogItem
 	*TransactionsNonCatalogPriceForAnExistingProduct
 	*TransactionsNonCatalogPriceAndProduct
 }
 
 // MarshalJSON implements the json.Marshaler interface.
-func (u CountryAndZipPostalCodeItems) MarshalJSON() ([]byte, error) {
+func (u TransactionPreviewByAddressItems) MarshalJSON() ([]byte, error) {
 	if u.TransactionsCatalogItem != nil {
 		return json.Marshal(u.TransactionsCatalogItem)
 	}
@@ -513,8 +513,8 @@ func (u CountryAndZipPostalCodeItems) MarshalJSON() ([]byte, error) {
 	return nil, nil
 }
 
-// CountryAndZipPostalCode: Paddle uses the country and ZIP code (where supplied) to calculate totals.
-type CountryAndZipPostalCode struct {
+// TransactionPreviewByAddress: Paddle uses the country and ZIP code (where supplied) to calculate totals.
+type TransactionPreviewByAddress struct {
 	// Address: Address for this transaction preview.
 	Address AddressPreview `json:"address,omitempty"`
 	// CustomerID: Paddle ID of the customer that this transaction preview is for, prefixed with `ctm_`.
@@ -530,47 +530,47 @@ type CountryAndZipPostalCode struct {
 	*/
 	IgnoreTrials bool `json:"ignore_trials,omitempty"`
 	// Items: Add a non-catalog price for a non-catalog product in your catalog to a transaction. In this case, the product and price that you're billing for are specific to this transaction.
-	Items []CountryAndZipPostalCodeItems `json:"items,omitempty"`
+	Items []TransactionPreviewByAddressItems `json:"items,omitempty"`
 }
 
-// NewIPAddressItemsTransactionsCatalogItem takes a TransactionsCatalogItem type
-// and creates a IPAddressItems for use in a request.
-func NewIPAddressItemsTransactionsCatalogItem(r *TransactionsCatalogItem) *IPAddressItems {
-	return &IPAddressItems{TransactionsCatalogItem: r}
+// NewTransactionPreviewByIPItemsTransactionsCatalogItem takes a TransactionsCatalogItem type
+// and creates a TransactionPreviewByIPItems for use in a request.
+func NewTransactionPreviewByIPItemsTransactionsCatalogItem(r *TransactionsCatalogItem) *TransactionPreviewByIPItems {
+	return &TransactionPreviewByIPItems{TransactionsCatalogItem: r}
 }
 
-// NewIPAddressItemsTransactionsNonCatalogPriceForAnExistingProduct takes a TransactionsNonCatalogPriceForAnExistingProduct type
-// and creates a IPAddressItems for use in a request.
-func NewIPAddressItemsTransactionsNonCatalogPriceForAnExistingProduct(r *TransactionsNonCatalogPriceForAnExistingProduct) *IPAddressItems {
-	return &IPAddressItems{TransactionsNonCatalogPriceForAnExistingProduct: r}
+// NewTransactionPreviewByIPItemsTransactionsNonCatalogPriceForAnExistingProduct takes a TransactionsNonCatalogPriceForAnExistingProduct type
+// and creates a TransactionPreviewByIPItems for use in a request.
+func NewTransactionPreviewByIPItemsTransactionsNonCatalogPriceForAnExistingProduct(r *TransactionsNonCatalogPriceForAnExistingProduct) *TransactionPreviewByIPItems {
+	return &TransactionPreviewByIPItems{TransactionsNonCatalogPriceForAnExistingProduct: r}
 }
 
-// NewIPAddressItemsTransactionsNonCatalogPriceAndProduct takes a TransactionsNonCatalogPriceAndProduct type
-// and creates a IPAddressItems for use in a request.
-func NewIPAddressItemsTransactionsNonCatalogPriceAndProduct(r *TransactionsNonCatalogPriceAndProduct) *IPAddressItems {
-	return &IPAddressItems{TransactionsNonCatalogPriceAndProduct: r}
+// NewTransactionPreviewByIPItemsTransactionsNonCatalogPriceAndProduct takes a TransactionsNonCatalogPriceAndProduct type
+// and creates a TransactionPreviewByIPItems for use in a request.
+func NewTransactionPreviewByIPItemsTransactionsNonCatalogPriceAndProduct(r *TransactionsNonCatalogPriceAndProduct) *TransactionPreviewByIPItems {
+	return &TransactionPreviewByIPItems{TransactionsNonCatalogPriceAndProduct: r}
 }
 
-// IPAddressItems represents a union request type of the following types:
+// TransactionPreviewByIPItems represents a union request type of the following types:
 //   - `TransactionsCatalogItem`
 //   - `TransactionsNonCatalogPriceForAnExistingProduct`
 //   - `TransactionsNonCatalogPriceAndProduct`
 //
 // The following constructor functions can be used to create a new instance of this type.
-//   - `NewIPAddressItemsTransactionsCatalogItem()`
-//   - `NewIPAddressItemsTransactionsNonCatalogPriceForAnExistingProduct()`
-//   - `NewIPAddressItemsTransactionsNonCatalogPriceAndProduct()`
+//   - `NewTransactionPreviewByIPItemsTransactionsCatalogItem()`
+//   - `NewTransactionPreviewByIPItemsTransactionsNonCatalogPriceForAnExistingProduct()`
+//   - `NewTransactionPreviewByIPItemsTransactionsNonCatalogPriceAndProduct()`
 //
 // Only one of the values can be set at a time, the first non-nil value will be used in the request.
 // Items: Add a non-catalog price for a non-catalog product in your catalog to a transaction. In this case, the product and price that you're billing for are specific to this transaction.
-type IPAddressItems struct {
+type TransactionPreviewByIPItems struct {
 	*TransactionsCatalogItem
 	*TransactionsNonCatalogPriceForAnExistingProduct
 	*TransactionsNonCatalogPriceAndProduct
 }
 
 // MarshalJSON implements the json.Marshaler interface.
-func (u IPAddressItems) MarshalJSON() ([]byte, error) {
+func (u TransactionPreviewByIPItems) MarshalJSON() ([]byte, error) {
 	if u.TransactionsCatalogItem != nil {
 		return json.Marshal(u.TransactionsCatalogItem)
 	}
@@ -586,8 +586,8 @@ func (u IPAddressItems) MarshalJSON() ([]byte, error) {
 	return nil, nil
 }
 
-// IPAddress: Paddle fetches location using the IP address to calculate totals.
-type IPAddress struct {
+// TransactionPreviewByIP: Paddle fetches location using the IP address to calculate totals.
+type TransactionPreviewByIP struct {
 	// CustomerIPAddress: IP address for this transaction preview.
 	CustomerIPAddress string `json:"customer_ip_address,omitempty"`
 	// CustomerID: Paddle ID of the customer that this transaction preview is for, prefixed with `ctm_`.
@@ -603,47 +603,47 @@ type IPAddress struct {
 	*/
 	IgnoreTrials bool `json:"ignore_trials,omitempty"`
 	// Items: Add a non-catalog price for a non-catalog product in your catalog to a transaction. In this case, the product and price that you're billing for are specific to this transaction.
-	Items []IPAddressItems `json:"items,omitempty"`
+	Items []TransactionPreviewByIPItems `json:"items,omitempty"`
 }
 
-// NewExistingCustomerPaddleIDsItemsTransactionsCatalogItem takes a TransactionsCatalogItem type
-// and creates a ExistingCustomerPaddleIDsItems for use in a request.
-func NewExistingCustomerPaddleIDsItemsTransactionsCatalogItem(r *TransactionsCatalogItem) *ExistingCustomerPaddleIDsItems {
-	return &ExistingCustomerPaddleIDsItems{TransactionsCatalogItem: r}
+// NewTransactionPreviewByCustomerItemsTransactionsCatalogItem takes a TransactionsCatalogItem type
+// and creates a TransactionPreviewByCustomerItems for use in a request.
+func NewTransactionPreviewByCustomerItemsTransactionsCatalogItem(r *TransactionsCatalogItem) *TransactionPreviewByCustomerItems {
+	return &TransactionPreviewByCustomerItems{TransactionsCatalogItem: r}
 }
 
-// NewExistingCustomerPaddleIDsItemsTransactionsNonCatalogPriceForAnExistingProduct takes a TransactionsNonCatalogPriceForAnExistingProduct type
-// and creates a ExistingCustomerPaddleIDsItems for use in a request.
-func NewExistingCustomerPaddleIDsItemsTransactionsNonCatalogPriceForAnExistingProduct(r *TransactionsNonCatalogPriceForAnExistingProduct) *ExistingCustomerPaddleIDsItems {
-	return &ExistingCustomerPaddleIDsItems{TransactionsNonCatalogPriceForAnExistingProduct: r}
+// NewTransactionPreviewByCustomerItemsTransactionsNonCatalogPriceForAnExistingProduct takes a TransactionsNonCatalogPriceForAnExistingProduct type
+// and creates a TransactionPreviewByCustomerItems for use in a request.
+func NewTransactionPreviewByCustomerItemsTransactionsNonCatalogPriceForAnExistingProduct(r *TransactionsNonCatalogPriceForAnExistingProduct) *TransactionPreviewByCustomerItems {
+	return &TransactionPreviewByCustomerItems{TransactionsNonCatalogPriceForAnExistingProduct: r}
 }
 
-// NewExistingCustomerPaddleIDsItemsTransactionsNonCatalogPriceAndProduct takes a TransactionsNonCatalogPriceAndProduct type
-// and creates a ExistingCustomerPaddleIDsItems for use in a request.
-func NewExistingCustomerPaddleIDsItemsTransactionsNonCatalogPriceAndProduct(r *TransactionsNonCatalogPriceAndProduct) *ExistingCustomerPaddleIDsItems {
-	return &ExistingCustomerPaddleIDsItems{TransactionsNonCatalogPriceAndProduct: r}
+// NewTransactionPreviewByCustomerItemsTransactionsNonCatalogPriceAndProduct takes a TransactionsNonCatalogPriceAndProduct type
+// and creates a TransactionPreviewByCustomerItems for use in a request.
+func NewTransactionPreviewByCustomerItemsTransactionsNonCatalogPriceAndProduct(r *TransactionsNonCatalogPriceAndProduct) *TransactionPreviewByCustomerItems {
+	return &TransactionPreviewByCustomerItems{TransactionsNonCatalogPriceAndProduct: r}
 }
 
-// ExistingCustomerPaddleIDsItems represents a union request type of the following types:
+// TransactionPreviewByCustomerItems represents a union request type of the following types:
 //   - `TransactionsCatalogItem`
 //   - `TransactionsNonCatalogPriceForAnExistingProduct`
 //   - `TransactionsNonCatalogPriceAndProduct`
 //
 // The following constructor functions can be used to create a new instance of this type.
-//   - `NewExistingCustomerPaddleIDsItemsTransactionsCatalogItem()`
-//   - `NewExistingCustomerPaddleIDsItemsTransactionsNonCatalogPriceForAnExistingProduct()`
-//   - `NewExistingCustomerPaddleIDsItemsTransactionsNonCatalogPriceAndProduct()`
+//   - `NewTransactionPreviewByCustomerItemsTransactionsCatalogItem()`
+//   - `NewTransactionPreviewByCustomerItemsTransactionsNonCatalogPriceForAnExistingProduct()`
+//   - `NewTransactionPreviewByCustomerItemsTransactionsNonCatalogPriceAndProduct()`
 //
 // Only one of the values can be set at a time, the first non-nil value will be used in the request.
 // Items: Add a non-catalog price for a non-catalog product in your catalog to a transaction. In this case, the product and price that you're billing for are specific to this transaction.
-type ExistingCustomerPaddleIDsItems struct {
+type TransactionPreviewByCustomerItems struct {
 	*TransactionsCatalogItem
 	*TransactionsNonCatalogPriceForAnExistingProduct
 	*TransactionsNonCatalogPriceAndProduct
 }
 
 // MarshalJSON implements the json.Marshaler interface.
-func (u ExistingCustomerPaddleIDsItems) MarshalJSON() ([]byte, error) {
+func (u TransactionPreviewByCustomerItems) MarshalJSON() ([]byte, error) {
 	if u.TransactionsCatalogItem != nil {
 		return json.Marshal(u.TransactionsCatalogItem)
 	}
@@ -659,8 +659,8 @@ func (u ExistingCustomerPaddleIDsItems) MarshalJSON() ([]byte, error) {
 	return nil, nil
 }
 
-// ExistingCustomerPaddleIDs: Paddle uses existing customer data to calculate totals. Typically used for logged-in customers.
-type ExistingCustomerPaddleIDs struct {
+// TransactionPreviewByCustomer: Paddle uses existing customer data to calculate totals. Typically used for logged-in customers.
+type TransactionPreviewByCustomer struct {
 	// AddressID: Paddle ID of the address that this transaction preview is for, prefixed with `add_`. Requires `customer_id`.
 	AddressID string `json:"address_id,omitempty"`
 	// BusinessID: Paddle ID of the business that this transaction preview is for, prefixed with `biz_`.
@@ -678,7 +678,7 @@ type ExistingCustomerPaddleIDs struct {
 	*/
 	IgnoreTrials bool `json:"ignore_trials,omitempty"`
 	// Items: Add a non-catalog price for a non-catalog product in your catalog to a transaction. In this case, the product and price that you're billing for are specific to this transaction.
-	Items []ExistingCustomerPaddleIDsItems `json:"items,omitempty"`
+	Items []TransactionPreviewByCustomerItems `json:"items,omitempty"`
 }
 
 // TransactionItemPreview: List of items to preview transaction calculations for.
@@ -987,43 +987,43 @@ func (c *TransactionsClient) CreateTransaction(ctx context.Context, req *CreateT
 	return res, nil
 }
 
-// NewPreviewTransactionRequestCountryAndZipPostalCode takes a CountryAndZipPostalCode type
-// and creates a PreviewTransactionRequest for use in a request.
-func NewPreviewTransactionRequestCountryAndZipPostalCode(r *CountryAndZipPostalCode) *PreviewTransactionRequest {
-	return &PreviewTransactionRequest{CountryAndZipPostalCode: r}
+// NewPreviewTransactionCreateRequestTransactionPreviewByAddress takes a TransactionPreviewByAddress type
+// and creates a PreviewTransactionCreateRequest for use in a request.
+func NewPreviewTransactionCreateRequestTransactionPreviewByAddress(r *TransactionPreviewByAddress) *PreviewTransactionCreateRequest {
+	return &PreviewTransactionCreateRequest{TransactionPreviewByAddress: r}
 }
 
-// NewPreviewTransactionRequestIPAddress takes a IPAddress type
-// and creates a PreviewTransactionRequest for use in a request.
-func NewPreviewTransactionRequestIPAddress(r *IPAddress) *PreviewTransactionRequest {
-	return &PreviewTransactionRequest{IPAddress: r}
+// NewPreviewTransactionCreateRequestTransactionPreviewByIP takes a TransactionPreviewByIP type
+// and creates a PreviewTransactionCreateRequest for use in a request.
+func NewPreviewTransactionCreateRequestTransactionPreviewByIP(r *TransactionPreviewByIP) *PreviewTransactionCreateRequest {
+	return &PreviewTransactionCreateRequest{TransactionPreviewByIP: r}
 }
 
-// NewPreviewTransactionRequestExistingCustomerPaddleIDs takes a ExistingCustomerPaddleIDs type
-// and creates a PreviewTransactionRequest for use in a request.
-func NewPreviewTransactionRequestExistingCustomerPaddleIDs(r *ExistingCustomerPaddleIDs) *PreviewTransactionRequest {
-	return &PreviewTransactionRequest{ExistingCustomerPaddleIDs: r}
+// NewPreviewTransactionCreateRequestTransactionPreviewByCustomer takes a TransactionPreviewByCustomer type
+// and creates a PreviewTransactionCreateRequest for use in a request.
+func NewPreviewTransactionCreateRequestTransactionPreviewByCustomer(r *TransactionPreviewByCustomer) *PreviewTransactionCreateRequest {
+	return &PreviewTransactionCreateRequest{TransactionPreviewByCustomer: r}
 }
 
-// PreviewTransactionRequest represents a union request type of the following types:
-//   - `CountryAndZipPostalCode`
-//   - `IPAddress`
-//   - `ExistingCustomerPaddleIDs`
+// PreviewTransactionCreateRequest represents a union request type of the following types:
+//   - `TransactionPreviewByAddress`
+//   - `TransactionPreviewByIP`
+//   - `TransactionPreviewByCustomer`
 //
 // The following constructor functions can be used to create a new instance of this type.
-//   - `NewPreviewTransactionRequestCountryAndZipPostalCode()`
-//   - `NewPreviewTransactionRequestIPAddress()`
-//   - `NewPreviewTransactionRequestExistingCustomerPaddleIDs()`
+//   - `NewPreviewTransactionCreateRequestTransactionPreviewByAddress()`
+//   - `NewPreviewTransactionCreateRequestTransactionPreviewByIP()`
+//   - `NewPreviewTransactionCreateRequestTransactionPreviewByCustomer()`
 //
 // Only one of the values can be set at a time, the first non-nil value will be used in the request.
-type PreviewTransactionRequest struct {
-	*CountryAndZipPostalCode
-	*IPAddress
-	*ExistingCustomerPaddleIDs
+type PreviewTransactionCreateRequest struct {
+	*TransactionPreviewByAddress
+	*TransactionPreviewByIP
+	*TransactionPreviewByCustomer
 }
 
-// PreviewTransaction performs the POST operation on a Transactions resource.
-func (c *TransactionsClient) PreviewTransaction(ctx context.Context, req *PreviewTransactionRequest) (res *TransactionPreview, err error) {
+// PreviewTransactionCreate performs the POST operation on a Transactions resource.
+func (c *TransactionsClient) PreviewTransactionCreate(ctx context.Context, req *PreviewTransactionCreateRequest) (res *TransactionPreview, err error) {
 	if err := c.doer.Do(ctx, "POST", "/transactions/preview", req, &res); err != nil {
 		return nil, err
 	}
@@ -1032,17 +1032,17 @@ func (c *TransactionsClient) PreviewTransaction(ctx context.Context, req *Previe
 }
 
 // MarshalJSON implements the json.Marshaler interface.
-func (u PreviewTransactionRequest) MarshalJSON() ([]byte, error) {
-	if u.CountryAndZipPostalCode != nil {
-		return json.Marshal(u.CountryAndZipPostalCode)
+func (u PreviewTransactionCreateRequest) MarshalJSON() ([]byte, error) {
+	if u.TransactionPreviewByAddress != nil {
+		return json.Marshal(u.TransactionPreviewByAddress)
 	}
 
-	if u.IPAddress != nil {
-		return json.Marshal(u.IPAddress)
+	if u.TransactionPreviewByIP != nil {
+		return json.Marshal(u.TransactionPreviewByIP)
 	}
 
-	if u.ExistingCustomerPaddleIDs != nil {
-		return json.Marshal(u.ExistingCustomerPaddleIDs)
+	if u.TransactionPreviewByCustomer != nil {
+		return json.Marshal(u.TransactionPreviewByCustomer)
 	}
 
 	return nil, nil


### PR DESCRIPTION
This PR aims to improve on some type definitions where the originally generated types were too generic and don't work well in a single package scope. 

This is broken out from a larger generation but _should_ be isolated to just these changes.

BREAKING CHANGE: Type have been renamed or consolidated.