### PR TITLE
fix: Incorrect type definitions for array properties

### DIFF
--- a/pkg/paddlenotification/shared.go
+++ b/pkg/paddlenotification/shared.go
@@ -445,7 +445,7 @@ type Money struct {
 // UnitPriceOverride: List of unit price overrides. Use to override the base price with a custom price and currency for a country or group of countries.
 type UnitPriceOverride struct {
 	// CountryCodes: Supported two-letter ISO 3166-1 alpha-2 country code.
-	CountryCodes CountryCode `json:"country_codes,omitempty"`
+	CountryCodes []CountryCode `json:"country_codes,omitempty"`
 	// UnitPrice: Override price. This price applies to customers located in the countries for this unit price override.
 	UnitPrice Money `json:"unit_price,omitempty"`
 }

--- a/pricing_preview.go
+++ b/pricing_preview.go
@@ -70,7 +70,7 @@ type PricePreview struct {
 	// Details: Calculated totals for a price preview, including discounts, tax, and currency conversion.
 	Details PricePreviewDetails `json:"details,omitempty"`
 	// AvailablePaymentMethods: List of available payment methods for Paddle Checkout given the price and location information passed.
-	AvailablePaymentMethods PaymentMethodType `json:"available_payment_methods,omitempty"`
+	AvailablePaymentMethods []PaymentMethodType `json:"available_payment_methods,omitempty"`
 }
 
 // PricingPreviewClient is a client for the Pricing preview resource.

--- a/shared.go
+++ b/shared.go
@@ -506,7 +506,7 @@ const (
 // UnitPriceOverride: List of unit price overrides. Use to override the base price with a custom price and currency for a country or group of countries.
 type UnitPriceOverride struct {
 	// CountryCodes: Supported two-letter ISO 3166-1 alpha-2 country code.
-	CountryCodes CountryCode `json:"country_codes,omitempty"`
+	CountryCodes []CountryCode `json:"country_codes,omitempty"`
 	// UnitPrice: Override price. This price applies to customers located in the countries for this unit price override.
 	UnitPrice Money `json:"unit_price,omitempty"`
 }

--- a/transactions.go
+++ b/transactions.go
@@ -333,7 +333,7 @@ type Transaction struct {
 	// Discount: Discount for this transaction. Returned when the `include` parameter is used with the `discount` value and the transaction has a `discount_id`.
 	Discount Discount `json:"discount,omitempty"`
 	// AvailablePaymentMethods: List of available payment methods for this transaction. Returned when the `include` parameter is used with the `available_payment_methods` value.
-	AvailablePaymentMethods PaymentMethodType `json:"available_payment_methods,omitempty"`
+	AvailablePaymentMethods []PaymentMethodType `json:"available_payment_methods,omitempty"`
 }
 
 // CatalogItem: Add a catalog item to a transaction. In this case, the product and price that you're billing for exist in your product catalog in Paddle.
@@ -754,7 +754,7 @@ type TransactionPreview struct {
 	// Details: Calculated totals for a transaction preview, including discounts, tax, and currency conversion. Considered the source of truth for totals on a transaction preview.
 	Details TransactionDetailsPreview `json:"details,omitempty"`
 	// AvailablePaymentMethods: List of available payment methods for Paddle Checkout given the price and location information passed.
-	AvailablePaymentMethods PaymentMethodType `json:"available_payment_methods,omitempty"`
+	AvailablePaymentMethods []PaymentMethodType `json:"available_payment_methods,omitempty"`
 }
 
 // TransactionsTransactionsCheckout: Paddle Checkout details for this transaction. You may pass a URL when creating or updating an automatically-collected transaction, or when creating or updating a manually-collected transaction where `billing_details.enable_checkout` is `true`.


### PR DESCRIPTION
- UnitPriceOverride.CountryCodes
- Transaction.AvailablePaymentMethods
- PricePreview.AvailablePaymentMethods