### PR TITLE
fix: Support nullable discount starts_at for subscriptions

### DIFF
--- a/pkg/paddlenotification/subscriptions.go
+++ b/pkg/paddlenotification/subscriptions.go
@@ -80,8 +80,8 @@ const (
 type SubscriptionDiscountTimePeriod struct {
 	// ID: Unique Paddle ID for this discount, prefixed with `dsc_`.
 	ID string `json:"id,omitempty"`
-	// StartsAt: RFC 3339 datetime string of when this discount was first applied.
-	StartsAt string `json:"starts_at,omitempty"`
+	// StartsAt: RFC 3339 datetime string of when this discount was first applied. `null` for canceled subscriptions where a discount was redeemed but never applied to a transaction.
+	StartsAt *string `json:"starts_at,omitempty"`
 	// EndsAt: RFC 3339 datetime string of when this discount no longer applies. Where a discount has `maximum_recurring_intervals`, this is the date of the last billing period where this discount applies. `null` where a discount recurs forever.
 	EndsAt *string `json:"ends_at,omitempty"`
 }

--- a/subscriptions.go
+++ b/subscriptions.go
@@ -402,8 +402,8 @@ const (
 type SubscriptionDiscountTimePeriod struct {
 	// ID: Unique Paddle ID for this discount, prefixed with `dsc_`.
 	ID string `json:"id,omitempty"`
-	// StartsAt: RFC 3339 datetime string of when this discount was first applied.
-	StartsAt string `json:"starts_at,omitempty"`
+	// StartsAt: RFC 3339 datetime string of when this discount was first applied. `null` for canceled subscriptions where a discount was redeemed but never applied to a transaction.
+	StartsAt *string `json:"starts_at,omitempty"`
 	// EndsAt: RFC 3339 datetime string of when this discount no longer applies. Where a discount has `maximum_recurring_intervals`, this is the date of the last billing period where this discount applies. `null` where a discount recurs forever.
 	EndsAt *string `json:"ends_at,omitempty"`
 }


### PR DESCRIPTION
A Subscription discount `starts_at` property can be `null` under certain conditions, to support this the property has changed to be a pointer. 