### PR TITLE
fix: Webhook verifier unbounded IO read

### DIFF
--- a/webhook_verifier.go
+++ b/webhook_verifier.go
@@ -54,7 +54,7 @@ func (wv *WebhookVerifier) Verify(req *http.Request) (bool, error) {
 	ts := matches[0][1]
 	h1 := matches[0][2]
 
-	const maxBodySize = 1 << 20 // 1 MB
+	const maxBodySize = 2 << 20 // 2 MB
 	limitedReader := io.LimitReader(req.Body, maxBodySize)
 
 	body, err := io.ReadAll(limitedReader)

--- a/webhook_verifier.go
+++ b/webhook_verifier.go
@@ -17,6 +17,9 @@ var (
 
 	// ErrInvalidSignatureFormat is returned when the signature format is invalid.
 	ErrInvalidSignatureFormat = errors.New("invalid signature format")
+
+	// ErrRequestExceedsExpectation is returned when the request exceeds the limit
+	ErrRequestExceedsExpectation = errors.New("request body size exceeds limit")
 )
 
 // signatureRegexp matches the Paddle-Signature header format, e.g.:
@@ -51,9 +54,16 @@ func (wv *WebhookVerifier) Verify(req *http.Request) (bool, error) {
 	ts := matches[0][1]
 	h1 := matches[0][2]
 
-	body, err := io.ReadAll(req.Body)
+	const maxBodySize = 1 << 20 // 1 MB
+	limitedReader := io.LimitReader(req.Body, maxBodySize)
+
+	body, err := io.ReadAll(limitedReader)
 	if err != nil {
 		return false, err
+	}
+
+	if len(body) == maxBodySize {
+		return false, ErrRequestExceedsExpectation
 	}
 
 	req.Body = io.NopCloser(bytes.NewBuffer(body))


### PR DESCRIPTION
This patch addresses a theoretical issue related to the webhook verifier's handling of large requests. While this is not an actual vulnerability, excessive resource consumption could occur if an attacker gained access to signing secrets and sent oversized payloads.