### PR TITLE
fix: Remove unused DiscountStatus values expired and used

### DIFF
--- a/pkg/paddlenotification/discounts.go
+++ b/pkg/paddlenotification/discounts.go
@@ -23,14 +23,12 @@ type DiscountUpdated struct {
 	Data DiscountNotification `json:"data"`
 }
 
-// DiscountStatus: Whether this entity can be used in Paddle. `expired` and `used` are set automatically by Paddle..
+// DiscountStatus: Whether this entity can be used in Paddle..
 type DiscountStatus string
 
 const (
 	DiscountStatusActive   DiscountStatus = "active"
 	DiscountStatusArchived DiscountStatus = "archived"
-	DiscountStatusExpired  DiscountStatus = "expired"
-	DiscountStatusUsed     DiscountStatus = "used"
 )
 
 // Type: Type of discount. Determines how this discount impacts the checkout or transaction total..

--- a/shared.go
+++ b/shared.go
@@ -1230,8 +1230,6 @@ type DiscountStatus string
 const (
 	DiscountStatusActive   DiscountStatus = "active"
 	DiscountStatusArchived DiscountStatus = "archived"
-	DiscountStatusExpired  DiscountStatus = "expired"
-	DiscountStatusUsed     DiscountStatus = "used"
 )
 
 // DiscountType: Type of discount. Determines how this discount impacts the checkout or transaction total..


### PR DESCRIPTION
DiscountStatuses `expired` and `used` were never returned from the API and thus can be safely removed