### PR TITLE
fix: Remove writeonly `items` from PricePreview entity

### DIFF
--- a/pricing_preview.go
+++ b/pricing_preview.go
@@ -65,8 +65,6 @@ type PricePreview struct {
 	Address *AddressPreview `json:"address,omitempty"`
 	// CustomerIPAddress: IP address for this transaction preview. Send one of `address_id`, `customer_ip_address`, or the `address` object when previewing.
 	CustomerIPAddress *string `json:"customer_ip_address,omitempty"`
-	// Items: List of items to preview price calculations for.
-	Items []PricePreviewItem `json:"items,omitempty"`
 	// Details: Calculated totals for a price preview, including discounts, tax, and currency conversion.
 	Details PricePreviewDetails `json:"details,omitempty"`
 	// AvailablePaymentMethods: List of available payment methods for Paddle Checkout given the price and location information passed.


### PR DESCRIPTION
`items` is not a response property on PreviewPrices, only a request property. This is marked as writeonly and is now being dropped from the `PricePreview` type