### PR TITLE
fix: bump Go version to 1.22.0

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.21'
+          go-version: '1.22'
 
       - name: Install dependencies
         run: go mod download

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/PaddleHQ/paddle-go-sdk/v3
 
-go 1.21.0
+go 1.22.0
 
 require (
 	github.com/ggicci/httpin v0.19.0


### PR DESCRIPTION
Bumping the Go version to `1.22.0` to resolve [vuln](https://github.com/advisories/GHSA-7wrw-r4p8-38rx) 