### PR TITLE
Extract go version from go.mod for use in actions

### DIFF
--- a/.github/workflows/check-semver.yml
+++ b/.github/workflows/check-semver.yml
@@ -9,12 +9,39 @@ on:
       - labeled
       - unlabeled
 
+permissions:
+  issues: read
+  pull-requests: read
+
+env:
+  VALID_SEMVER_LABELS: norelease,release:major,release:minor,release:patch
+
 jobs:
   check_labels:
     name: Check labels
     runs-on: ubuntu-latest
     steps:
-      - uses: docker://agilepathway/pull-request-label-checker:v1.6.13
+      - uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7
         with:
-          one_of: norelease,release:major,release:minor,release:patch
-          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const validLabels = process.env.VALID_SEMVER_LABELS.split(",");
+            const { data: labelResultList } = await github.rest.issues.listLabelsOnIssue({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number
+            });
+
+            const prLabels = labelResultList.map(label => label.name);
+            const semverLabels = prLabels.filter(value => validLabels.includes(value));
+
+            core.info(`Valid labels: ${validLabels.join(" | ")}`);
+            core.info(`PR labels: ${prLabels.join(" | ")}`);
+            core.info(`Semver Labels: ${semverLabels.join(" | ")}`);
+
+            if (semverLabels.length == 0) {
+              core.setFailed("You must add a SemVer label of one of ${validLabels.join(" | ")} to this PR");
+            }
+
+            if (semverLabels.length > 1) {
+              core.setFailed("You must only add one SemVer label to this PR");
+            }

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,19 +1,39 @@
 name: go
 
 on:
-  - push
+  pull_request:
+
+permissions:
+  contents: read
+  pull-requests: write
+  security-events: write
+  actions: read
 
 jobs:
   build:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Extract Go version
+        uses: arnested/go-version-action@8a203e9ff069cbbf4e3b65cb248101cfe307c71c # v1.1.18
+        id: go-version
+
+      - name: Split version code
+        uses: xom9ikk/split@10ba6c9f71c5953bc304e21781213e933b043891 #v1.1
+        id: split
+        with:
+          string: ${{ steps.go-version.outputs.go-mod-version }}
+          separator: .
+          limit: 2
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34 # v5.3.0
         with:
-          go-version: '1.21'
+          go-version: '${{ steps.split.outputs._0 }}.${{ steps.split.outputs._1 }}'
+          check-latest: true
+          cache: true
 
       - name: Install dependencies
         run: go mod download
@@ -30,13 +50,10 @@ jobs:
       - name: Go Generate
         run: go generate ./... && git diff --exit-code
 
-      - name: Install `govulncheck`
-        run: go install golang.org/x/vuln/cmd/govulncheck@latest
-
       - id: govulncheck
         uses: golang/govulncheck-action@b625fbe08f3bccbe446d94fbf87fcc875a4f50ee # v1.0.4
         with:
-          go-version-input: '1.21'
+          go-version-input: '${{ steps.split.outputs._0 }}.${{ steps.split.outputs._1 }}'
           go-package: ./...
           output-format: sarif
           output-file: results.sarif

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -2,9 +2,11 @@ name: Linting
 
 on:
   pull_request:
-  push:
-    branches:
-      - master
+
+permissions:
+  contents: read
+  pull-requests: read
+  checks: write
 
 jobs:
   golangci:
@@ -12,16 +14,20 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          persist-credentials: false
 
       - name: golangci-lint
-        uses: reviewdog/action-golangci-lint@v2
+        uses: reviewdog/action-golangci-lint@dd3fda91790ca90e75049e5c767509dc0ec7d99b # v2
         with:
           reporter: github-pr-review
           fail_on_error: true
           filter_mode: nofilter
 
+      - name: Install editorconfig-checker
+        uses: editorconfig-checker/action-editorconfig-checker@d2ed4fd072ae6f887e9407c909af0f585d2ad9f4 # v2
+
       - name: eclint
-        uses: reviewdog/action-eclint@v1
-        with:
-          github_token: ${{ secrets.github_token }}
+        run: editorconfig-checker

--- a/.github/workflows/release-on-push.yml
+++ b/.github/workflows/release-on-push.yml
@@ -5,13 +5,17 @@ on:
     branches:
       - main
 
+permissions:
+  contents: write
+  pull-requests: read
+
 jobs:
   release_on_push:
     runs-on: ubuntu-latest
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
-      - uses: rymndhng/release-on-push-action@v0.28.0
+      - uses: rymndhng/release-on-push-action@aebba2bbce07a9474bf95e8710e5ee8a9e922fe2 # v0.28.0
         with:
           bump_version_scheme: norelease
           use_github_release_notes: true


### PR DESCRIPTION
1. Use the go version from `go.mod` to make maintenance easier
2. Use commit references of actions
3. Replace the deprecated eclint task