### PR TITLE
Prevent build from failing on govulncheck reports

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -33,8 +33,19 @@ jobs:
       - name: Install `govulncheck`
         run: go install golang.org/x/vuln/cmd/govulncheck@latest
 
-      - name: Run `govulncheck`
-        run: govulncheck ./...
+      - id: govulncheck
+        uses: golang/govulncheck-action@b625fbe08f3bccbe446d94fbf87fcc875a4f50ee # v1.0.4
+        with:
+          go-version-input: '1.21'
+          go-package: ./...
+          output-format: sarif
+          output-file: results.sarif
+
+      - name: Upload SARIF file
+        uses: github/codeql-action/upload-sarif@dd746615b3b9d728a6a37ca2045b68ca76d4841a # v3.28.8
+        with:
+          sarif_file: results.sarif
+          category: govulncheck
 
       - name: Vet
         run: go vet ./...


### PR DESCRIPTION
Push `govulncheck` reports to Github Advanced Security instead of failing the PR.