### PR TITLE
feat: Support AdjustmentAction chargeback_warning_reverse

### DIFF
--- a/adjustments.go
+++ b/adjustments.go
@@ -124,12 +124,13 @@ var ErrAdjustmentCannotAdjustImportedTransaction = &paddleerr.Error{
 type AdjustmentActionQuery string
 
 const (
-	AdjustmentActionQueryChargeback        AdjustmentActionQuery = "chargeback"
-	AdjustmentActionQueryChargebackReverse AdjustmentActionQuery = "chargeback_reverse"
-	AdjustmentActionQueryChargebackWarning AdjustmentActionQuery = "chargeback_warning"
-	AdjustmentActionQueryCredit            AdjustmentActionQuery = "credit"
-	AdjustmentActionQueryCreditReverse     AdjustmentActionQuery = "credit_reverse"
-	AdjustmentActionQueryRefund            AdjustmentActionQuery = "refund"
+	AdjustmentActionQueryChargeback               AdjustmentActionQuery = "chargeback"
+	AdjustmentActionQueryChargebackReverse        AdjustmentActionQuery = "chargeback_reverse"
+	AdjustmentActionQueryChargebackWarning        AdjustmentActionQuery = "chargeback_warning"
+	AdjustmentActionQueryChargebackWarningReverse AdjustmentActionQuery = "chargeback_warning_reverse"
+	AdjustmentActionQueryCredit                   AdjustmentActionQuery = "credit"
+	AdjustmentActionQueryCreditReverse            AdjustmentActionQuery = "credit_reverse"
+	AdjustmentActionQueryRefund                   AdjustmentActionQuery = "refund"
 )
 
 type AdjustmentCreditNotePDF struct {

--- a/pkg/paddlenotification/adjustments.go
+++ b/pkg/paddlenotification/adjustments.go
@@ -20,12 +20,13 @@ type AdjustmentUpdated struct {
 type AdjustmentAction string
 
 const (
-	AdjustmentActionCredit            AdjustmentAction = "credit"
-	AdjustmentActionRefund            AdjustmentAction = "refund"
-	AdjustmentActionChargeback        AdjustmentAction = "chargeback"
-	AdjustmentActionChargebackReverse AdjustmentAction = "chargeback_reverse"
-	AdjustmentActionChargebackWarning AdjustmentAction = "chargeback_warning"
-	AdjustmentActionCreditReverse     AdjustmentAction = "credit_reverse"
+	AdjustmentActionCredit                   AdjustmentAction = "credit"
+	AdjustmentActionRefund                   AdjustmentAction = "refund"
+	AdjustmentActionChargeback               AdjustmentAction = "chargeback"
+	AdjustmentActionChargebackReverse        AdjustmentAction = "chargeback_reverse"
+	AdjustmentActionChargebackWarning        AdjustmentAction = "chargeback_warning"
+	AdjustmentActionChargebackWarningReverse AdjustmentAction = "chargeback_warning_reverse"
+	AdjustmentActionCreditReverse            AdjustmentAction = "credit_reverse"
 )
 
 // AdjustmentType: Type of adjustment. Use `full` to adjust the grand total for the related transaction. Include an `items` array when creating a `partial` adjustment. If omitted, defaults to `partial`..

--- a/shared.go
+++ b/shared.go
@@ -1026,12 +1026,13 @@ type Address struct {
 type AdjustmentAction string
 
 const (
-	AdjustmentActionCredit            AdjustmentAction = "credit"
-	AdjustmentActionRefund            AdjustmentAction = "refund"
-	AdjustmentActionChargeback        AdjustmentAction = "chargeback"
-	AdjustmentActionChargebackReverse AdjustmentAction = "chargeback_reverse"
-	AdjustmentActionChargebackWarning AdjustmentAction = "chargeback_warning"
-	AdjustmentActionCreditReverse     AdjustmentAction = "credit_reverse"
+	AdjustmentActionCredit                   AdjustmentAction = "credit"
+	AdjustmentActionRefund                   AdjustmentAction = "refund"
+	AdjustmentActionChargeback               AdjustmentAction = "chargeback"
+	AdjustmentActionChargebackReverse        AdjustmentAction = "chargeback_reverse"
+	AdjustmentActionChargebackWarning        AdjustmentAction = "chargeback_warning"
+	AdjustmentActionChargebackWarningReverse AdjustmentAction = "chargeback_warning_reverse"
+	AdjustmentActionCreditReverse            AdjustmentAction = "credit_reverse"
 )
 
 // AdjustmentType: Type of adjustment. Use `full` to adjust the grand total for the related transaction. Include an `items` array when creating a `partial` adjustment. If omitted, defaults to `partial`..


### PR DESCRIPTION
feat: Support AdjustmentAction chargeback_warning_reverse

Reversal of a chargeback warning for the related transaction

feat: Support AdjustmentAction chargeback_warning_reverse

Support added to notifications, query params and response entities