### PR TITLE
chore(go): Increase minimum Go version to 1.23

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/PaddleHQ/paddle-go-sdk/v3
 
-go 1.21.0
+go 1.23
 
 require (
 	github.com/ggicci/httpin v0.19.0


### PR DESCRIPTION
chore(go): Increase minimum Go version to 1.23

This aligns with the GoLang release policy

chore(go): Align GoLang release policy to 1.23