### PR TITLE
chore(go)!: Increase minimum Go version to 1.25

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/PaddleHQ/paddle-go-sdk/v4
 
-go 1.23.0
+go 1.25.0
 
 require (
 	github.com/ggicci/httpin v0.20.2


### PR DESCRIPTION
Aligns with Go's latest 2 versions support rules after the release of 1.26 this month.

BREAKING CHANGE: Drops support for running with Go version 1.23 and 1.24