### PR TITLE
feat(api-keys): add support for API key exposures

### DIFF
--- a/events.go
+++ b/events.go
@@ -84,6 +84,12 @@ type APIKeyRevokedEvent struct {
 	Data paddlenotification.APIKeyNotification `json:"data"`
 }
 
+// APIKeyExposureCreatedEvent represents an Event implementation for api_key_exposure.created event.
+type APIKeyExposureCreatedEvent struct {
+	GenericEvent
+	Data paddlenotification.APIKeyExposureNotification `json:"data"`
+}
+
 // BusinessCreatedEvent represents an Event implementation for business.created event.
 type BusinessCreatedEvent struct {
 	GenericEvent
@@ -383,6 +389,8 @@ func unmarshalEvent(data []byte) (Event, error) {
 		t = &APIKeyExpiringEvent{}
 	case "api_key.revoked":
 		t = &APIKeyRevokedEvent{}
+	case "api_key_exposure.created":
+		t = &APIKeyExposureCreatedEvent{}
 	case "business.created":
 		t = &BusinessCreatedEvent{}
 	case "business.imported":

--- a/notifications.go
+++ b/notifications.go
@@ -140,6 +140,8 @@ func (n *Notification) UnmarshalJSON(data []byte) error {
 		t = &paddlenotification.APIKeyExpiring{}
 	case "api_key.revoked":
 		t = &paddlenotification.APIKeyRevoked{}
+	case "api_key_exposure.created":
+		t = &paddlenotification.APIKeyExposureCreated{}
 	case "business.created":
 		t = &paddlenotification.BusinessCreated{}
 	case "business.imported":

--- a/pkg/paddlenotification/api_keys.go
+++ b/pkg/paddlenotification/api_keys.go
@@ -37,6 +37,13 @@ type APIKeyRevoked struct {
 	Data APIKeyNotification `json:"data"`
 }
 
+// APIKeyExposureCreated represents the api_key_exposure.created event.
+// See https://developer.paddle.com/webhooks/overview for more information.
+type APIKeyExposureCreated struct {
+	GenericNotificationEvent
+	Data APIKeyExposureNotification `json:"data"`
+}
+
 // APIKeyStatus: Status of this API key..
 type APIKeyStatus string
 
@@ -100,6 +107,8 @@ type APIKeyNotification struct {
 	Status APIKeyStatus `json:"status"`
 	// Permissions: Permission assigned to this API key.
 	Permissions []APIKeyPermission `json:"permissions"`
+	// ExposedAt: RFC 3339 datetime string of when this API key was first exposed. `null` if never exposed.
+	ExposedAt *string `json:"exposed_at"`
 	// ExpiresAt: RFC 3339 datetime string of when this API key expires.
 	ExpiresAt *string `json:"expires_at"`
 	// LastUsedAt: RFC 3339 datetime string of when this API key was last used (accurate to within 1 hour). `null` if never used.
@@ -108,4 +117,47 @@ type APIKeyNotification struct {
 	CreatedAt string `json:"created_at"`
 	// UpdatedAt: RFC 3339 datetime string of when this entity was updated. Set automatically by Paddle.
 	UpdatedAt string `json:"updated_at"`
+}
+
+// APIKeyExposureLevel: Risk level of this exposure..
+type APIKeyExposureLevel string
+
+const (
+	APIKeyExposureLevelHigh APIKeyExposureLevel = "high"
+	APIKeyExposureLevelLow  APIKeyExposureLevel = "low"
+)
+
+// APIKeyExposureActionTaken: Action performed by Paddle as a result of this exposure..
+type APIKeyExposureActionTaken string
+
+const (
+	APIKeyExposureActionTakenRevoked APIKeyExposureActionTaken = "revoked"
+	APIKeyExposureActionTakenNone    APIKeyExposureActionTaken = "none"
+)
+
+// APIKeyExposureSource: Source of this exposure..
+type APIKeyExposureSource string
+
+const APIKeyExposureSourceGithub APIKeyExposureSource = "github"
+
+// APIKeyExposureNotification: New or changed entity.
+type APIKeyExposureNotification struct {
+	NotificationPayload `json:"-"`
+
+	// ID: Unique Paddle ID for this API key exposure entity, prefixed with `apkexp_`.
+	ID string `json:"id"`
+	// APIKeyID: Unique Paddle ID for this API key entity, prefixed with `apikey_`.
+	APIKeyID string `json:"api_key_id"`
+	// RiskLevel: Risk level of this exposure.
+	RiskLevel APIKeyExposureLevel `json:"risk_level"`
+	// ActionTaken: Action performed by Paddle as a result of this exposure.
+	ActionTaken APIKeyExposureActionTaken `json:"action_taken"`
+	// Source: Source of this exposure.
+	Source APIKeyExposureSource `json:"source"`
+	// Reference: A unique URL or reference pointing to the source of the exposure. When `source` is `github`, a URL to the location of the exposure is returned.
+	Reference string `json:"reference"`
+	// Description: Additional details about this exposure.
+	Description *string `json:"description"`
+	// CreatedAt: RFC 3339 datetime string of when this API key exposure was found. Set automatically by Paddle.
+	CreatedAt string `json:"created_at"`
 }

--- a/pkg/paddlenotification/shared.go
+++ b/pkg/paddlenotification/shared.go
@@ -16,6 +16,7 @@ const (
 	EventTypeNameAPIKeyExpiring           EventTypeName = "api_key.expiring"
 	EventTypeNameAPIKeyRevoked            EventTypeName = "api_key.revoked"
 	EventTypeNameAPIKeyUpdated            EventTypeName = "api_key.updated"
+	EventTypeNameAPIKeyExposureCreated    EventTypeName = "api_key_exposure.created"
 	EventTypeNameBusinessCreated          EventTypeName = "business.created"
 	EventTypeNameBusinessImported         EventTypeName = "business.imported"
 	EventTypeNameBusinessUpdated          EventTypeName = "business.updated"

--- a/shared.go
+++ b/shared.go
@@ -1496,6 +1496,7 @@ const (
 	EventTypeNameAPIKeyExpiring           EventTypeName = "api_key.expiring"
 	EventTypeNameAPIKeyRevoked            EventTypeName = "api_key.revoked"
 	EventTypeNameAPIKeyUpdated            EventTypeName = "api_key.updated"
+	EventTypeNameAPIKeyExposureCreated    EventTypeName = "api_key_exposure.created"
 	EventTypeNameBusinessCreated          EventTypeName = "business.created"
 	EventTypeNameBusinessImported         EventTypeName = "business.imported"
 	EventTypeNameBusinessUpdated          EventTypeName = "business.updated"
@@ -1568,6 +1569,7 @@ const (
 	SimulationTypeNameAPIKeyExpiring           SimulationTypeName = "api_key.expiring"
 	SimulationTypeNameAPIKeyRevoked            SimulationTypeName = "api_key.revoked"
 	SimulationTypeNameAPIKeyUpdated            SimulationTypeName = "api_key.updated"
+	SimulationTypeNameAPIKeyExposureCreated    SimulationTypeName = "api_key_exposure.created"
 	SimulationTypeNameBusinessCreated          SimulationTypeName = "business.created"
 	SimulationTypeNameBusinessImported         SimulationTypeName = "business.imported"
 	SimulationTypeNameBusinessUpdated          SimulationTypeName = "business.updated"
@@ -1707,6 +1709,8 @@ func (s *SimulationEvent) UnmarshalJSON(data []byte) error {
 			t = &paddlenotification.AdjustmentNotification{}
 		case "api_key":
 			t = &paddlenotification.APIKeyNotification{}
+		case "api_key_exposure":
+			t = &paddlenotification.APIKeyExposureNotification{}
 		case "business":
 			t = &paddlenotification.BusinessNotification{}
 		case "client_token":

--- a/simulations.go
+++ b/simulations.go
@@ -241,6 +241,8 @@ func (s *Simulation) UnmarshalJSON(data []byte) error {
 			t = &paddlenotification.AdjustmentNotification{}
 		case "api_key":
 			t = &paddlenotification.APIKeyNotification{}
+		case "api_key_exposure":
+			t = &paddlenotification.APIKeyExposureNotification{}
 		case "business":
 			t = &paddlenotification.BusinessNotification{}
 		case "client_token":


### PR DESCRIPTION
Adds support for API Key Exposures

- New APIKeyExposureCreated type for api_key_exposure.created event
- Event name constants for api_key_exposure.created event
- New ExposedAt field on APIKeyNotification type
