### PR TITLE
feat!: support requires_payment_method on price trial_period

### DIFF
--- a/pkg/paddlenotification/prices.go
+++ b/pkg/paddlenotification/prices.go
@@ -40,7 +40,7 @@ type PriceNotification struct {
 	// BillingCycle: How often this price should be charged. `null` if price is non-recurring (one-time).
 	BillingCycle *Duration `json:"billing_cycle"`
 	// TrialPeriod: Trial period for the product related to this price. The billing cycle begins once the trial period is over. `null` for no trial period. Requires `billing_cycle`.
-	TrialPeriod *Duration `json:"trial_period"`
+	TrialPeriod *TrialPeriod `json:"trial_period"`
 	// TaxMode: How tax is calculated for this price.
 	TaxMode TaxMode `json:"tax_mode"`
 	// UnitPrice: Base price. This price applies to all customers, except for customers located in countries where you have `unit_price_overrides`.

--- a/pkg/paddlenotification/shared.go
+++ b/pkg/paddlenotification/shared.go
@@ -475,6 +475,16 @@ type PriceQuantity struct {
 	Maximum int `json:"maximum,omitempty"`
 }
 
+// TrialPeriod: Trial period for the product related to this price. The billing cycle begins once the trial period is over. `null` for no trial period. Requires `billing_cycle`.
+type TrialPeriod struct {
+	// Interval: Unit of time.
+	Interval Interval `json:"interval,omitempty"`
+	// Frequency: Amount of time.
+	Frequency int `json:"frequency,omitempty"`
+	// RequiresPaymentMethod: Whether this price requires a payment method (`true`) or not (`false`) when trialing. If `false`, customers can sign up for subscription without entering their payment details, often referred to as a "cardless trial."
+	RequiresPaymentMethod bool `json:"requires_payment_method,omitempty"`
+}
+
 // TaxCategory: Tax category for this product. Used for charging the correct rate of tax. Selected tax category must be enabled on your Paddle account..
 type TaxCategory string
 
@@ -525,7 +535,7 @@ type Price struct {
 	// BillingCycle: How often this price should be charged. `null` if price is non-recurring (one-time).
 	BillingCycle *Duration `json:"billing_cycle,omitempty"`
 	// TrialPeriod: Trial period for the product related to this price. The billing cycle begins once the trial period is over. `null` for no trial period. Requires `billing_cycle`.
-	TrialPeriod *Duration `json:"trial_period,omitempty"`
+	TrialPeriod *TrialPeriod `json:"trial_period,omitempty"`
 	// TaxMode: How tax is calculated for this price.
 	TaxMode TaxMode `json:"tax_mode,omitempty"`
 	// UnitPrice: Base price. This price applies to all customers, except for customers located in countries where you have `unit_price_overrides`.

--- a/prices.go
+++ b/prices.go
@@ -64,7 +64,7 @@ type Price struct {
 	// BillingCycle: How often this price should be charged. `null` if price is non-recurring (one-time).
 	BillingCycle *Duration `json:"billing_cycle,omitempty"`
 	// TrialPeriod: Trial period for the product related to this price. The billing cycle begins once the trial period is over. `null` for no trial period. Requires `billing_cycle`.
-	TrialPeriod *Duration `json:"trial_period,omitempty"`
+	TrialPeriod *TrialPeriod `json:"trial_period,omitempty"`
 	// TaxMode: How tax is calculated for this price.
 	TaxMode TaxMode `json:"tax_mode,omitempty"`
 	// UnitPrice: Base price. This price applies to all customers, except for customers located in countries where you have `unit_price_overrides`.
@@ -159,7 +159,7 @@ type CreatePriceRequest struct {
 	   TrialPeriod: Trial period for the product related to this price. The billing cycle begins once the trial period is over.
 	   `null` for no trial period. Requires `billing_cycle`. If omitted, defaults to `null`.
 	*/
-	TrialPeriod *Duration `json:"trial_period,omitempty"`
+	TrialPeriod *TrialPeriod `json:"trial_period,omitempty"`
 	// TaxMode: How tax is calculated for this price. If omitted, defaults to `account_setting`.
 	TaxMode *TaxMode `json:"tax_mode,omitempty"`
 	// UnitPriceOverrides: List of unit price overrides. Use to override the base price with a custom price and currency for a country or group of countries.
@@ -212,7 +212,7 @@ type UpdatePriceRequest struct {
 	// BillingCycle: How often this price should be charged. `null` if price is non-recurring (one-time).
 	BillingCycle *PatchField[*Duration] `json:"billing_cycle,omitempty"`
 	// TrialPeriod: Trial period for the product related to this price. The billing cycle begins once the trial period is over. `null` for no trial period. Requires `billing_cycle`.
-	TrialPeriod *PatchField[*Duration] `json:"trial_period,omitempty"`
+	TrialPeriod *PatchField[*TrialPeriod] `json:"trial_period,omitempty"`
 	// TaxMode: How tax is calculated for this price.
 	TaxMode *PatchField[TaxMode] `json:"tax_mode,omitempty"`
 	// UnitPrice: Base price. This price applies to all customers, except for customers located in countries where you have `unit_price_overrides`.

--- a/shared.go
+++ b/shared.go
@@ -258,6 +258,16 @@ type Duration struct {
 	Frequency int `json:"frequency,omitempty"`
 }
 
+// TrialPeriod: Trial period for the product related to this price. The billing cycle begins once the trial period is over. `null` for no trial period. Requires `billing_cycle`.
+type TrialPeriod struct {
+	// Interval: Unit of time.
+	Interval Interval `json:"interval,omitempty"`
+	// Frequency: Amount of time.
+	Frequency int `json:"frequency,omitempty"`
+	// RequiresPaymentMethod: Whether this price requires a payment method (`true`) or not (`false`) when trialing. If `false`, customers can sign up for subscription without entering their payment details, often referred to as a "cardless trial."
+	RequiresPaymentMethod bool `json:"requires_payment_method,omitempty"`
+}
+
 // TaxMode: How tax is calculated for this price..
 type TaxMode string
 
@@ -1382,7 +1392,7 @@ type TransactionPriceCreateWithProductID struct {
 	// BillingCycle: How often this price should be charged. `null` if price is non-recurring (one-time).
 	BillingCycle *Duration `json:"billing_cycle,omitempty"`
 	// TrialPeriod: Trial period for the product related to this price. The billing cycle begins once the trial period is over. `null` for no trial period. Requires `billing_cycle`.
-	TrialPeriod *Duration `json:"trial_period,omitempty"`
+	TrialPeriod *TrialPeriod `json:"trial_period,omitempty"`
 	// TaxMode: How tax is calculated for this price.
 	TaxMode TaxMode `json:"tax_mode,omitempty"`
 	// UnitPrice: Base price. This price applies to all customers, except for customers located in countries where you have `unit_price_overrides`.
@@ -1420,7 +1430,7 @@ type TransactionPriceCreateWithProduct struct {
 	// BillingCycle: How often this price should be charged. `null` if price is non-recurring (one-time).
 	BillingCycle *Duration `json:"billing_cycle,omitempty"`
 	// TrialPeriod: Trial period for the product related to this price. The billing cycle begins once the trial period is over. `null` for no trial period. Requires `billing_cycle`.
-	TrialPeriod *Duration `json:"trial_period,omitempty"`
+	TrialPeriod *TrialPeriod `json:"trial_period,omitempty"`
 	// TaxMode: How tax is calculated for this price.
 	TaxMode TaxMode `json:"tax_mode,omitempty"`
 	// UnitPrice: Base price. This price applies to all customers, except for customers located in countries where you have `unit_price_overrides`.

--- a/transactions.go
+++ b/transactions.go
@@ -827,7 +827,7 @@ type TransactionPricePreview struct {
 	// BillingCycle: How often this price should be charged. `null` if price is non-recurring (one-time).
 	BillingCycle *Duration `json:"billing_cycle,omitempty"`
 	// TrialPeriod: Trial period for the product related to this price. The billing cycle begins once the trial period is over. `null` for no trial period. Requires `billing_cycle`.
-	TrialPeriod *Duration `json:"trial_period,omitempty"`
+	TrialPeriod *TrialPeriod `json:"trial_period,omitempty"`
 	// TaxMode: How tax is calculated for this price.
 	TaxMode TaxMode `json:"tax_mode,omitempty"`
 	// UnitPrice: Base price. This price applies to all customers, except for customers located in countries where you have `unit_price_overrides`.


### PR DESCRIPTION
BREAKING CHANGE: `TrialPeriod` property for Price entities has changed type from `Duration` to `TrialPeriod` to support `RequiresPaymentMethod`
