### PR TITLE
feat: parse Retry-After header on API errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,6 +176,7 @@ These testable examples use a mock server that returns predefined responses. Thi
 - [Simulations](./example_simulations_test.go)
 - [Webhook Unmarshalling](./example_webhook_unmarshal_test.go)
 - [Webhook Verification](./example_webhook_verifier_test.go)
+- [429 Error Retry Handling](./example_retry_after_test.go)
 
 These are not intended to be comprehensive for each and every operation. Instead, they cover the general flow of operations for entities as well as some useful examples. 
 

--- a/example_retry_after_test.go
+++ b/example_retry_after_test.go
@@ -1,0 +1,60 @@
+package paddle_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"os"
+
+	paddle "github.com/PaddleHQ/paddle-go-sdk/v4"
+	"github.com/PaddleHQ/paddle-go-sdk/v4/pkg/paddleerr"
+)
+
+// Demonstrates how to handle rate limiting and retry scenarios using the Retry-After header.
+// This example shows a realistic pattern for scheduling retries in a background job queue
+// or processing system when the API returns a 429 Too Many Requests response with a
+// Retry-After header. The RetryAfter information is available on paddleerr.Error for
+// known API errors such as too_many_requests.
+func Example_retryAfter() {
+	// Create a mock HTTP server that simulates rate limiting with Retry-After.
+	s := mockServerForExample(mockServerResponse{
+		stub:       &stub{paths: []stubPath{tooManyRequestsError}},
+		statusCode: http.StatusTooManyRequests,
+		headers: http.Header{
+			"Retry-After": []string{"120"},
+		},
+	})
+
+	// Create a new Paddle client.
+	client, err := paddle.New(
+		os.Getenv("PADDLE_API_KEY"),
+		paddle.WithBaseURL(s.URL), // Uses the mock server, you will not need this in your integration.
+	)
+
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+
+	ctx := context.Background()
+
+	// Make an API call which will return a 429 response.
+	// For this example we'll ignore the response
+	_, err = client.GetTransaction(ctx, &paddle.GetTransactionRequest{
+		TransactionID: "txn_01hv8m0mnx3sj85e7gxc6kga03",
+	})
+
+	var apiErr *paddleerr.Error
+	if errors.As(err, &apiErr) && apiErr.RetryAfter != nil {
+		fmt.Printf("Error indicates total delay: ~%ds\n", int(apiErr.RetryAfter.TotalDelay().Seconds()))
+		fmt.Printf("RetryAt expired check: %t\n", apiErr.RetryAfter.IsExpired())
+
+		// Here you would add logic to retry this call later, e.g. re-enqueuing with a delay.
+		// You can utilise RetryAfter.WaitTime() to get a relative delay from when the request was parsed.
+	}
+
+	// Output:
+	// Error indicates total delay: ~120s
+	// RetryAt expired check: false
+}

--- a/internal/response/response_api_error_handler.go
+++ b/internal/response/response_api_error_handler.go
@@ -54,5 +54,10 @@ func HandleError(req *http.Request, res *http.Response, requestErr error) error 
 		return NewError(ErrUnexpectedResponse, req.Method, req.URL.Path, res.StatusCode, teedBytes.Bytes())
 	}
 
+	apiResponse.Error.Status = res.StatusCode
+	if retry := parseRetry(res.Header); retry != nil {
+		apiResponse.Error.RetryAfter = retry
+	}
+
 	return apiResponse.Error
 }

--- a/internal/response/response_headers.go
+++ b/internal/response/response_headers.go
@@ -1,0 +1,45 @@
+package response
+
+import (
+	"net/http"
+	"strconv"
+	"time"
+
+	"github.com/PaddleHQ/paddle-go-sdk/v4/pkg/paddleerr"
+)
+
+// parseRetry extracts Retry-After from response headers.
+func parseRetry(headers http.Header) *paddleerr.RetryAfter {
+	retryAfterValue := headers.Get("Retry-After")
+	if retryAfterValue == "" {
+		return nil
+	}
+
+	now := time.Now()
+
+	// Try parsing as integer (seconds)
+	if seconds, err := strconv.Atoi(retryAfterValue); err == nil {
+		return &paddleerr.RetryAfter{
+			IssuedAt: now,
+			RetryAt:  now.Add(time.Duration(seconds) * time.Second),
+		}
+	}
+
+	// Try parsing as HTTP date (RFC 7231)
+	if parsed, err := time.Parse(time.RFC1123, retryAfterValue); err == nil {
+		return &paddleerr.RetryAfter{
+			IssuedAt: now,
+			RetryAt:  parsed,
+		}
+	}
+
+	// Try parsing as HTTP date with numeric timezone
+	if parsed, err := time.Parse(time.RFC1123Z, retryAfterValue); err == nil {
+		return &paddleerr.RetryAfter{
+			IssuedAt: now,
+			RetryAt:  parsed,
+		}
+	}
+
+	return nil
+}

--- a/testdata/too_many_requests_error.json
+++ b/testdata/too_many_requests_error.json
@@ -1,0 +1,11 @@
+{
+  "error": {
+    "type": "request_error",
+    "code": "too_many_requests",
+    "detail": "IP address exceeded the allowed rate limit. Retry after the number of seconds in the Retry-After header.",
+    "documentation_url": "https://developer.paddle.com/errors/shared/too_many_requests"
+  },
+  "meta": {
+    "request_id": "9346b365-4cad-43a6-b7c1-48ff6a1c7836"
+  }
+}


### PR DESCRIPTION
Expose Retry-After information on paddleerr.Error for rate limiting
and retry scenarios. Supports both integer seconds and HTTP-date
(RFC1123/RFC1123Z) formats per RFC 7231.

  - Add RetryAfter struct to paddleerr with TotalDelay(), WaitTime(),
    IsExpired()
  - Populate Status and RetryAfter on paddleerr.Error in HandleError
  - Add parseRetry in response package for header parsing
  - Extend mockServerResponse with statusCode and headers for tests
  - Add Example_retryAfter demonstrating Retry-After handling
