### PR TITLE
fix: transaction update example

### DIFF
--- a/example_update_test.go
+++ b/example_update_test.go
@@ -32,7 +32,8 @@ func Example_update() {
 
 	// Update a transaction.
 	res, err := client.UpdateTransaction(ctx, &paddle.UpdateTransactionRequest{
-		DiscountID: paddle.NewPtrPatchField("dsc_01gtgztp8fpchantd5g1wrksa3"),
+		TransactionID: "txn_01hv8m0mnx3sj85e7gxc6kga03",
+		DiscountID:    paddle.NewPtrPatchField("dsc_01gtgztp8fpchantd5g1wrksa3"),
 		Items: paddle.NewPatchField([]paddle.UpdateTransactionItems{
 			*paddle.NewUpdateTransactionItemsTransactionItemFromCatalog(&paddle.TransactionItemFromCatalog{
 				Quantity: 50,


### PR DESCRIPTION
Missing TransactionID on transaction update example. Due to this utilising a mock server the response would always come back successful, in the real world this would have returned an API error. 
